### PR TITLE
fix: build deb packages in build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ build:
 			fi; \
 		done; \
 	fi
+	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
+	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
 	# rm -rf .coredns-build
 
 build-docker-image:


### PR DESCRIPTION
## Summary

- Restores the deb packaging invocations in the `build` Makefile target that were accidentally removed in 2126f5d
- Without these lines, `make validate-in-docker` fails because the `.deb` files are never created