### PR TITLE
feat: add PTR (reverse DNS) record support

### DIFF
--- a/Corefile.example
+++ b/Corefile.example
@@ -1,4 +1,4 @@
-docker:1053 {
+docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
     ready {
         monitor continuously
     }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The docker plugin serves DNS records for containers running on the local Docker daemon. It follows the Docker event stream, picking up changes whenever something happens to a container - whether it gets created, started, deleted, or restarted.
 
-The plugin resolves container names, network aliases, DNS names, and SRV records to their respective container IP addresses within a specified network.
+The plugin resolves container names, network aliases, DNS names, SRV records, and PTR (reverse DNS) records to their respective container IP addresses within a specified network.
 
 ### SRV Records via Docker Labels
 
@@ -174,6 +174,38 @@ The plugin generates a synthetic NS record for each configured zone apex. When q
 
 NS queries for names other than the zone apex (e.g., `dig web.docker NS`) are not handled by the NS record generator and will return a NODATA response if the name exists.
 
+### Reverse DNS (PTR Records)
+
+The plugin automatically generates PTR (reverse DNS) records for all container IP addresses. This allows reverse lookups from IP addresses back to container FQDNs, which is useful for log analysis, connection identification, and authentication schemes.
+
+**How it works:**
+
+- For every A/AAAA record generated, a corresponding PTR record is created mapping the reverse ARPA name to the container's FQDN.
+- IPv4 addresses use the `in-addr.arpa.` zone (e.g., `172.17.0.2` becomes `2.0.17.172.in-addr.arpa.`).
+- IPv6 addresses use the `ip6.arpa.` zone in nibble format (e.g., `2001:db8::1` becomes `1.0.0.0...8.b.d.0.1.0.0.2.ip6.arpa.`).
+- If multiple containers share the same IP, or a container has multiple names, all FQDNs are returned in the PTR response.
+- Wildcard names (e.g., `*.web.docker.`) are excluded from PTR records.
+
+**Server block configuration:**
+
+Since PTR queries use `in-addr.arpa.` and `ip6.arpa.` zones (which are outside your configured zones), you must add these reverse zones to your CoreDNS server block declaration:
+
+```text
+docker.localhost:1053 in-addr.arpa:1053 ip6.arpa:1053 {
+    docker {
+        zone docker.localhost
+    }
+}
+```
+
+When a PTR query does not match any known container IP, it is passed to the next plugin in the chain.
+
+**Example:**
+
+```bash
+dig -x 172.17.0.2 @127.0.0.1 -p 1053
+```
+
 ## Compilation
 
 To build coredns with this plugin enabled, run the following command in this repository:
@@ -220,6 +252,7 @@ If monitoring is enabled (via the *prometheus* directive) the following metrics 
 - `coredns_docker_last_sync_timestamp_seconds` - Unix timestamp of the last successful record sync from Docker. This can be used to monitor how fresh the plugin's data is.
 - `coredns_docker_records_total` - Number of A/AAAA DNS record names currently tracked.
 - `coredns_docker_srv_records_total` - Number of SRV DNS record names currently tracked.
+- `coredns_docker_ptr_records_total` - Number of PTR DNS record names currently tracked.
 - `coredns_docker_connected` - Whether the plugin is connected to the Docker daemon (1 = connected, 0 = disconnected).
 - `coredns_docker_containers_total` - Number of Docker containers currently tracked.
 - `coredns_docker_sync_duration_seconds` - Histogram of record sync durations in seconds.
@@ -237,7 +270,7 @@ When the Docker daemon becomes unreachable, the plugin continues serving the las
 
 During stale mode:
 
-- All previously synced A, AAAA, and SRV records continue to be served.
+- All previously synced A, AAAA, SRV, and PTR records continue to be served.
 - The TTL on stale responses is reduced to 5 seconds (or the configured TTL if it is already 5 seconds or lower). This encourages DNS clients to re-query frequently, so they pick up fresh records as soon as the daemon reconnects.
 - The `coredns_docker_last_sync_timestamp_seconds` metric can be used to monitor how long the plugin has been operating on stale data.
 - The plugin remains "ready" as long as it has previously synced at least once, even if the daemon is currently disconnected.
@@ -249,7 +282,7 @@ Once the Docker daemon becomes reachable again, the plugin automatically reconne
 To enable debug logging for the docker plugin, add the `debug` directive to your Corefile:
 
 ```text
-docker:1053 {
+docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
     debug
     docker {
         zone docker.localhost
@@ -267,6 +300,8 @@ When debug logging is enabled, the plugin logs messages at key decision points t
 | `Query <name> not in zones [<zones>], passing to next plugin` | The query name does not match any configured zone, so the query is forwarded to the next plugin in the chain. |
 | `Lookup results for <name>: A/AAAA records=<n>, SRV records=<n>, connected=<bool>` | Shows the number of matching records found in the internal cache and the Docker connection status. |
 | `Wildcard match for <name> via <wildcard>` | No exact match was found, but a wildcard record matched. The query name's leftmost label was replaced with `*` to find the match. |
+| `PTR lookup for <name>: <n> record(s), connected=<bool>` | A PTR (reverse DNS) query matched a known container IP. Shows the number of FQDNs and connection status. |
+| `No PTR records for <name>, passing to next plugin` | A PTR query did not match any known container IP, so the query is forwarded to the next plugin. |
 | `No records found for <name>, falling through to next plugin` | No records exist for the name and `fallthrough` is configured, so the query is forwarded to the next plugin. |
 | `SOA query at zone apex for <zone>` | A SOA query was received for the zone apex, and the synthetic SOA record is returned as the answer. |
 | `NS query at zone apex for <zone>` | An NS query was received for the zone apex, and the synthetic NS record is returned as the answer. |
@@ -283,7 +318,7 @@ When debug logging is enabled, the plugin logs messages at key decision points t
 | `Configuration: zones=[<zones>], ttl=<n>, label_prefix=<prefix>, networks=[<networks>], max_backoff=<duration>` | Logs the parsed plugin configuration at startup. |
 | `Connected to Docker daemon` | The plugin successfully connected (or reconnected) to the Docker daemon. |
 | `Found <n> running containers` | The number of containers discovered during a record sync. |
-| `Synced <n> records and <n> SRV records` | The number of DNS records generated after a sync. |
+| `Synced <n> records, <n> SRV records, and <n> PTR records` | The number of DNS records generated after a sync. |
 
 ### Readiness Checks
 
@@ -298,10 +333,10 @@ Debug logging has minimal performance overhead when disabled. When the `debug` d
 
 ## Examples
 
-Enable docker with and resolve all containers with `.docker.localhost` as the suffix.
+Enable docker with and resolve all containers with `.docker.localhost` as the suffix. The `in-addr.arpa` and `ip6.arpa` zones enable reverse DNS (PTR) lookups.
 
 ```text
-docker:1053 {
+docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
     docker {
         zone docker.localhost
     }
@@ -312,7 +347,7 @@ docker:1053 {
 Enable docker with multiple zones. Containers will be resolvable under both `.docker.localhost` and `.internal.localhost`. Note that all zones must also be listed in the server block declaration.
 
 ```text
-docker.localhost:1053 internal.localhost:1053 {
+docker.localhost:1053 internal.localhost:1053 in-addr.arpa:1053 ip6.arpa:1053 {
     docker {
         zone docker.localhost internal.localhost
     }
@@ -403,6 +438,27 @@ dig docker @127.0.0.1 -p 1053 NS
 
 ;; ANSWER SECTION:
 docker. 30 IN NS ns.dns.docker.
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.1#1053(127.0.0.1) (UDP)
+```
+
+### PTR record (reverse DNS)
+
+```shell
+dig -x 172.17.0.2 @127.0.0.1 -p 1053
+
+; <<>> DiG 9.18.1-1ubuntu1.2-Ubuntu <<>> -x 172.17.0.2 @127.0.0.1 -p 1053
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54321
+;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;2.0.17.172.in-addr.arpa.  IN PTR
+
+;; ANSWER SECTION:
+2.0.17.172.in-addr.arpa. 30 IN PTR web.docker.
 
 ;; Query time: 0 msec
 ;; SERVER: 127.0.0.1#1053(127.0.0.1) (UDP)

--- a/docker.go
+++ b/docker.go
@@ -47,6 +47,7 @@ type Docker struct {
 	mu           sync.RWMutex
 	records      map[string][]net.IP
 	srvs         map[string][]srvRecord
+	ptrs         map[string][]string // reverse-arpa FQDN -> container FQDNs
 	connected    bool
 	lastSyncTime time.Time
 }
@@ -66,6 +67,55 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	qname := strings.ToLower(state.Name())
 	qtype := state.QType()
 	log.Debugf("Query: qname=%s qtype=%s", qname, dns.TypeToString[qtype])
+
+	// Handle PTR queries (reverse DNS) before zone check.
+	// PTR queries use in-addr.arpa/ip6.arpa zones which are outside our configured zones.
+	if qtype == dns.TypePTR {
+		d.mu.RLock()
+		ptrs, ptrOk := d.ptrs[qname]
+		isConnected := d.connected
+		d.mu.RUnlock()
+
+		if !ptrOk {
+			log.Debugf("No PTR records for %s, passing to next plugin", qname)
+			return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
+		}
+
+		log.Debugf("PTR lookup for %s: %d record(s), connected=%t", qname, len(ptrs), isConnected)
+
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+		m.Compress = true
+
+		ttl := d.ttl
+		if !isConnected && ttl > 5 {
+			ttl = 5
+			requestStaleCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		}
+
+		for _, fqdn := range ptrs {
+			m.Answer = append(m.Answer, &dns.PTR{
+				Hdr: dns.RR_Header{
+					Name:   state.QName(),
+					Rrtype: dns.TypePTR,
+					Class:  dns.ClassINET,
+					Ttl:    ttl,
+				},
+				Ptr: fqdn,
+			})
+		}
+
+		log.Debugf("Response for %s PTR: %d answer(s)", qname, len(m.Answer))
+
+		if err := w.WriteMsg(m); err != nil {
+			log.Errorf("Failed to write message: %v", err)
+			requestFailedCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		} else {
+			requestSuccessCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		}
+		return dns.RcodeSuccess, nil
+	}
 
 	zone := plugin.Zones(d.zones).Matches(qname)
 	if zone == "" {
@@ -335,7 +385,7 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	}
 	log.Debugf("Found %d running containers", len(containers))
 
-	newRecords, newSrvs := generateRecords(ctx, GenerateRecordsInput{
+	newRecords, newSrvs, newPtrs := generateRecords(ctx, GenerateRecordsInput{
 		Containers:  containers,
 		Zones:       d.zones,
 		Inspector:   d.client,
@@ -346,14 +396,16 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	d.mu.Lock()
 	d.records = newRecords
 	d.srvs = newSrvs
+	d.ptrs = newPtrs
 	d.lastSyncTime = time.Now()
 	d.mu.Unlock()
 	lastSyncTimestamp.Set(float64(time.Now().Unix()))
 	syncDuration.Observe(time.Since(syncStart).Seconds())
 	recordsCount.Set(float64(len(newRecords)))
 	srvRecordsCount.Set(float64(len(newSrvs)))
+	ptrRecordsCount.Set(float64(len(newPtrs)))
 	containersCount.Set(float64(len(containers)))
-	log.Debugf("Synced %d records and %d SRV records", len(newRecords), len(newSrvs))
+	log.Debugf("Synced %d records, %d SRV records, and %d PTR records", len(newRecords), len(newSrvs), len(newPtrs))
 }
 
 // ContainerInspector is an interface for inspecting containers.
@@ -376,9 +428,10 @@ type GenerateRecordsInput struct {
 }
 
 // generateRecords generates the records for the containers.
-func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[string][]net.IP, map[string][]srvRecord) {
+func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[string][]net.IP, map[string][]srvRecord, map[string][]string) {
 	newRecords := make(map[string][]net.IP)
 	newSrvs := make(map[string][]srvRecord)
+	newPtrs := make(map[string][]string)
 
 	for _, c := range input.Containers {
 		inspect, err := input.Inspector.ContainerInspect(ctx, c.ID)
@@ -537,6 +590,11 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 				continue
 			}
 
+			arpa, arpaErr := dns.ReverseAddr(ip.String())
+			if arpaErr != nil {
+				log.Debugf("Container %s has IP %s that cannot be reversed: %v", c.ID, ip.String(), arpaErr)
+			}
+
 			names := []string{baseName}
 			names = append(names, ne.settings.Aliases...)
 			names = append(names, ne.settings.DNSNames...)
@@ -557,6 +615,9 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 						fqdn += "."
 					}
 					newRecords[fqdn] = append(newRecords[fqdn], ip)
+					if arpaErr == nil {
+						newPtrs[arpa] = append(newPtrs[arpa], fqdn)
+					}
 
 					if enableWildcard {
 						wildcardFqdn := "*." + fqdn
@@ -583,5 +644,5 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 		}
 	}
 
-	return newRecords, newSrvs
+	return newRecords, newSrvs, newPtrs
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -46,6 +46,14 @@ func TestDocker(t *testing.T) {
 				{target: "db.docker.", port: 5432},
 			},
 		},
+		ptrs: map[string][]string{
+			"2.0.17.172.in-addr.arpa.":                                                      {"web.docker."},
+			"3.0.17.172.in-addr.arpa.":                                                      {"db.docker."},
+			"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.": {"ipv6.docker."},
+			"4.0.17.172.in-addr.arpa.":                                                      {"multi.docker."},
+			"5.0.17.172.in-addr.arpa.":                                                      {"multi.docker."},
+			"6.0.17.172.in-addr.arpa.":                                                      {"myproj.mysvc.docker."},
+		},
 	}
 
 	var cases = []test.Case{
@@ -182,6 +190,24 @@ func TestDocker(t *testing.T) {
 				test.SOA("docker. 30 IN SOA ns.dns.docker. hostmaster.docker. 0 7200 1800 86400 30"),
 			},
 		},
+		{
+			// PTR record for IPv4
+			Qname: "2.0.17.172.in-addr.arpa.",
+			Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("2.0.17.172.in-addr.arpa. 30 IN PTR web.docker."),
+			},
+		},
+		{
+			// PTR record for IPv6
+			Qname: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.",
+			Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa. 30 IN PTR ipv6.docker."),
+			},
+		},
 	}
 
 	ctx := context.Background()
@@ -209,6 +235,102 @@ func TestDocker(t *testing.T) {
 	}
 }
 
+func TestDockerPTR(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records: map[string][]net.IP{
+			"web.docker.": {net.ParseIP("172.17.0.2")},
+			"app.docker.": {net.ParseIP("172.17.0.2")},
+		},
+		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{
+			"2.0.17.172.in-addr.arpa.": {"web.docker.", "app.docker."},
+		},
+	}
+
+	var cases = []test.Case{
+		{
+			// PTR with multiple FQDNs (sorted alphabetically for SortAndCheck)
+			Qname: "2.0.17.172.in-addr.arpa.",
+			Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("2.0.17.172.in-addr.arpa. 30 IN PTR app.docker."),
+				test.PTR("2.0.17.172.in-addr.arpa. 30 IN PTR web.docker."),
+			},
+		},
+		{
+			// Unknown reverse IP passes to next plugin (SERVFAIL from ErrorHandler)
+			Qname:  "9.9.9.9.in-addr.arpa.",
+			Qtype:  dns.TypePTR,
+			Rcode:  dns.RcodeServerFailure,
+			Answer: []dns.RR{},
+		},
+	}
+
+	ctx := context.Background()
+
+	for i, tc := range cases {
+		r := tc.Msg()
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := d.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d (%s): expected error %v, got %v", i, tc.Qname, tc.Error, err)
+			continue
+		}
+
+		if w.Msg == nil {
+			if tc.Rcode != dns.RcodeSuccess || len(tc.Answer) != 0 {
+				t.Errorf("Test %d (%s): nil message", i, tc.Qname)
+			}
+			continue
+		}
+
+		if err := test.SortAndCheck(w.Msg, tc); err != nil {
+			t.Errorf("Test %d (%s): %v", i, tc.Qname, err)
+		}
+	}
+}
+
+func TestDockerPTRStaleTTL(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: false,
+		zones:     []string{"docker."},
+		records:   map[string][]net.IP{},
+		srvs:      map[string][]srvRecord{},
+		ptrs: map[string][]string{
+			"2.0.17.172.in-addr.arpa.": {"web.docker."},
+		},
+	}
+
+	tc := test.Case{
+		Qname: "2.0.17.172.in-addr.arpa.",
+		Qtype: dns.TypePTR,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.PTR("2.0.17.172.in-addr.arpa. 5 IN PTR web.docker."),
+		},
+	}
+
+	r := tc.Msg()
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err := d.ServeDNS(context.Background(), w, r)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if err := test.SortAndCheck(w.Msg, tc); err != nil {
+		t.Errorf("error: %v", err)
+	}
+}
+
 func TestDockerEmptyPrefix(t *testing.T) {
 	d := &Docker{
 		Next:        test.ErrorHandler(),
@@ -221,6 +343,7 @@ func TestDockerEmptyPrefix(t *testing.T) {
 				{target: "web.docker.", port: 80},
 			},
 		},
+		ptrs: map[string][]string{},
 	}
 
 	tc := test.Case{
@@ -264,6 +387,7 @@ func TestDockerWildcard(t *testing.T) {
 				{target: "web.docker.", port: 80},
 			},
 		},
+		ptrs: map[string][]string{},
 	}
 
 	var cases = []test.Case{
@@ -362,6 +486,7 @@ func TestDockerFallthrough(t *testing.T) {
 			"web.docker.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	var cases = []test.Case{
@@ -419,6 +544,7 @@ func TestDockerFallthroughZoneSpecific(t *testing.T) {
 			"web.docker.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	// Nonexistent name in docker. zone does NOT match fallthrough zone "other."
@@ -464,6 +590,7 @@ func TestDockerMultiZone(t *testing.T) {
 				{target: "web.internal.", port: 80},
 			},
 		},
+		ptrs: map[string][]string{},
 	}
 
 	var cases = []test.Case{
@@ -544,6 +671,7 @@ func TestDockerSOAMultiZone(t *testing.T) {
 			"web.internal.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	var cases = []test.Case{
@@ -664,6 +792,7 @@ func TestDockerStaleTTL(t *testing.T) {
 				{target: "web.docker.", port: 80},
 			},
 		},
+		ptrs: map[string][]string{},
 	}
 
 	var cases = []test.Case{
@@ -713,6 +842,7 @@ func TestDockerStaleTTLLowTTL(t *testing.T) {
 			"web.docker.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	tc := test.Case{
@@ -747,6 +877,7 @@ func TestDockerConnectedNormalTTL(t *testing.T) {
 			"web.docker.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	tc := test.Case{
@@ -788,6 +919,7 @@ func TestServeDNSRequestDurationMetric(t *testing.T) {
 			"web.docker.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	obs := requestDuration.WithLabelValues("", "A")
@@ -818,6 +950,7 @@ func TestServeDNSStaleRequestMetric(t *testing.T) {
 			"web.docker.": {net.ParseIP("172.17.0.2")},
 		},
 		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
 	}
 
 	beforeCount := testutil.ToFloat64(requestStaleCount.WithLabelValues(""))
@@ -862,6 +995,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 				"web.docker.": {net.ParseIP("172.17.0.2")},
 			},
 			srvs: map[string][]srvRecord{},
+			ptrs: map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -885,6 +1019,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 			zones:     []string{"docker."},
 			records:   map[string][]net.IP{},
 			srvs:      map[string][]srvRecord{},
+			ptrs:      map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -910,6 +1045,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 				"web.docker.": {net.ParseIP("172.17.0.2")},
 			},
 			srvs: map[string][]srvRecord{},
+			ptrs: map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -933,6 +1069,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 			zones:     []string{"docker."},
 			records:   map[string][]net.IP{},
 			srvs:      map[string][]srvRecord{},
+			ptrs:      map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -957,6 +1094,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 			Fall:      fall.Root,
 			records:   map[string][]net.IP{},
 			srvs:      map[string][]srvRecord{},
+			ptrs:      map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -982,6 +1120,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 				"web.docker.": {net.ParseIP("172.17.0.2")},
 			},
 			srvs: map[string][]srvRecord{},
+			ptrs: map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -1007,6 +1146,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 				"web.docker.": {net.ParseIP("172.17.0.2")},
 			},
 			srvs: map[string][]srvRecord{},
+			ptrs: map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -1032,6 +1172,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 				"web.docker.": {net.ParseIP("172.17.0.2")},
 			},
 			srvs: map[string][]srvRecord{},
+			ptrs: map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -1057,6 +1198,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 				"*.web.docker.": {net.ParseIP("172.17.0.2")},
 			},
 			srvs: map[string][]srvRecord{},
+			ptrs: map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -1080,6 +1222,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 			zones:     []string{"docker."},
 			records:   map[string][]net.IP{},
 			srvs:      map[string][]srvRecord{},
+			ptrs:      map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -1103,6 +1246,7 @@ func TestServeDNSDebugLogging(t *testing.T) {
 			zones:     []string{"docker."},
 			records:   map[string][]net.IP{},
 			srvs:      map[string][]srvRecord{},
+			ptrs:      map[string][]string{},
 		}
 
 		m := new(dns.Msg)
@@ -1113,6 +1257,56 @@ func TestServeDNSDebugLogging(t *testing.T) {
 		output := buf.String()
 		if !strings.Contains(output, "NS query at zone apex for docker.") {
 			t.Errorf("expected NS query debug log, got: %s", output)
+		}
+	})
+
+	t.Run("ptr_query", func(t *testing.T) {
+		buf := enableDebugLog(t)
+
+		d := &Docker{
+			Next:      test.ErrorHandler(),
+			ttl:       DefaultTTL,
+			connected: true,
+			zones:     []string{"docker."},
+			records:   map[string][]net.IP{},
+			srvs:      map[string][]srvRecord{},
+			ptrs: map[string][]string{
+				"2.0.17.172.in-addr.arpa.": {"web.docker."},
+			},
+		}
+
+		m := new(dns.Msg)
+		m.SetQuestion("2.0.17.172.in-addr.arpa.", dns.TypePTR)
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+		d.ServeDNS(context.Background(), w, m)
+
+		output := buf.String()
+		if !strings.Contains(output, "PTR lookup for 2.0.17.172.in-addr.arpa.") {
+			t.Errorf("expected PTR lookup debug log, got: %s", output)
+		}
+	})
+
+	t.Run("ptr_not_found", func(t *testing.T) {
+		buf := enableDebugLog(t)
+
+		d := &Docker{
+			Next:      test.ErrorHandler(),
+			ttl:       DefaultTTL,
+			connected: true,
+			zones:     []string{"docker."},
+			records:   map[string][]net.IP{},
+			srvs:      map[string][]srvRecord{},
+			ptrs:      map[string][]string{},
+		}
+
+		m := new(dns.Msg)
+		m.SetQuestion("9.9.9.9.in-addr.arpa.", dns.TypePTR)
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+		d.ServeDNS(context.Background(), w, m)
+
+		output := buf.String()
+		if !strings.Contains(output, "No PTR records for 9.9.9.9.in-addr.arpa.") {
+			t.Errorf("expected no PTR records debug log, got: %s", output)
 		}
 	})
 }

--- a/e2e.bats
+++ b/e2e.bats
@@ -19,7 +19,7 @@ setup_file() {
   COREFILE="$(mktemp /tmp/Corefile.e2e.XXXXXX)"
   export COREFILE
   cat >"$COREFILE" <<EOF
-${COREDNS_ZONE}:${COREDNS_PORT} {
+${COREDNS_ZONE}:${COREDNS_PORT} in-addr.arpa:${COREDNS_PORT} ip6.arpa:${COREDNS_PORT} {
     log
     errors
     debug
@@ -118,6 +118,24 @@ wait_for_record_on_port() {
     i=$((i + 1))
   done
   echo "Record $name ($type) not found on port $port after waiting" >&2
+  return 1
+}
+
+wait_for_ptr_record() {
+  local ip="$1"
+  local retries=20
+  local i=0
+  while [ "$i" -lt "$retries" ]; do
+    local result
+    result=$(dig +short +time=1 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" -x "$ip" 2>/dev/null)
+    if [ -n "$result" ]; then
+      echo "$result"
+      return 0
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+  echo "PTR record for $ip not found after waiting" >&2
   return 1
 }
 
@@ -517,4 +535,38 @@ EOF
   kill "$MULTI_PID" 2>/dev/null || true
   wait "$MULTI_PID" 2>/dev/null || true
   rm -f "$MULTI_COREFILE"
+}
+
+@test "[e2e] PTR record: reverse DNS for container IP resolves" {
+  docker run -d --name coredns-e2e-ptr --network bridge alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-ptr.${COREDNS_ZONE}"
+  assert_success
+  local container_ip="$output"
+
+  run wait_for_ptr_record "$container_ip"
+  assert_success
+  assert_output_contains "coredns-e2e-ptr.${COREDNS_ZONE}."
+
+  docker rm -f coredns-e2e-ptr
+}
+
+@test "[e2e] PTR record: reverse DNS cleared after container removal" {
+  docker run -d --name coredns-e2e-ptr-rm --network bridge alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-ptr-rm.${COREDNS_ZONE}"
+  assert_success
+  local container_ip="$output"
+
+  run wait_for_ptr_record "$container_ip"
+  assert_success
+
+  docker rm -f coredns-e2e-ptr-rm
+
+  run wait_for_record_gone "coredns-e2e-ptr-rm.${COREDNS_ZONE}"
+  assert_success
+
+  # PTR should also be gone
+  run dig +short +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" -x "$container_ip"
+  [[ -z "$output" ]]
 }

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	"github.com/miekg/dns"
 )
 
 // mockContainerInspector is a mock container inspector for testing
@@ -19,6 +20,14 @@ func (m *mockContainerInspector) ContainerInspect(ctx context.Context, container
 	return m.inspections[containerID], nil
 }
 
+func mustReverseAddr(ip string) string {
+	arpa, err := dns.ReverseAddr(ip)
+	if err != nil {
+		panic(err)
+	}
+	return arpa
+}
+
 func TestGenerateRecords(t *testing.T) {
 	ctx := context.Background()
 
@@ -28,6 +37,7 @@ func TestGenerateRecords(t *testing.T) {
 		expected struct {
 			records map[string][]net.IP
 			srvs    map[string][]srvRecord
+			ptrs    map[string][]string
 		}
 	}{
 		{
@@ -64,11 +74,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -106,6 +118,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
@@ -113,6 +126,7 @@ func TestGenerateRecords(t *testing.T) {
 					"app.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "www.docker.", "app.docker."}},
 			},
 		},
 		{
@@ -152,12 +166,14 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"myproj_mysvc_1.docker.": {net.ParseIP("172.17.0.3")},
 					"myproj.mysvc.docker.":   {net.ParseIP("172.17.0.3")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.3"): {"myproj_mysvc_1.docker.", "myproj.mysvc.docker."}},
 			},
 		},
 		{
@@ -196,6 +212,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
@@ -205,6 +222,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "web.docker.", port: 80},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -247,6 +265,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"db.docker.": {net.ParseIP("172.17.0.3")},
@@ -256,6 +275,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "db.docker.", port: 5432},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.3"): {"db.docker."}},
 			},
 		},
 		{
@@ -298,6 +318,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"app.docker.": {net.ParseIP("172.17.0.4")},
@@ -310,6 +331,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "app.docker.", port: 8080},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.4"): {"app.docker."}},
 			},
 		},
 		{
@@ -366,11 +388,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -409,6 +433,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
@@ -418,6 +443,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "web.docker.", port: 80},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -456,11 +482,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -499,11 +527,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -546,11 +576,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -593,11 +625,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -637,6 +671,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
@@ -649,6 +684,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "web.docker.", port: 65535},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -692,6 +728,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
@@ -704,6 +741,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "web.docker.", port: 65535},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -731,9 +769,11 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{},
 				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
 			},
 		},
 		{
@@ -762,9 +802,11 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{},
 				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
 			},
 		},
 		{
@@ -797,11 +839,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -836,11 +880,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("10.0.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("10.0.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -875,11 +921,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2"), net.ParseIP("10.0.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}, mustReverseAddr("10.0.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -913,11 +961,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -954,12 +1004,14 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"web.internal.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "web.internal."}},
 			},
 		},
 		{
@@ -998,6 +1050,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
@@ -1011,6 +1064,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "web.internal.", port: 80},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "web.internal."}},
 			},
 		},
 		{
@@ -1049,12 +1103,14 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"myapp.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "myapp.docker."}},
 			},
 		},
 		{
@@ -1093,6 +1149,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":  {net.ParseIP("172.17.0.2")},
@@ -1101,6 +1158,7 @@ func TestGenerateRecords(t *testing.T) {
 					"app3.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "app1.docker.", "app2.docker.", "app3.docker."}},
 			},
 		},
 		{
@@ -1139,6 +1197,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":  {net.ParseIP("172.17.0.2")},
@@ -1147,6 +1206,7 @@ func TestGenerateRecords(t *testing.T) {
 					"app3.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "app1.docker.", "app2.docker.", "app3.docker."}},
 			},
 		},
 		{
@@ -1185,11 +1245,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -1228,11 +1290,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -1271,12 +1335,14 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"myapp.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "myapp.docker."}},
 			},
 		},
 		{
@@ -1316,6 +1382,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
@@ -1329,6 +1396,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "myapp.docker.", port: 80},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "myapp.docker."}},
 			},
 		},
 		{
@@ -1367,6 +1435,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":     {net.ParseIP("172.17.0.2")},
@@ -1375,6 +1444,7 @@ func TestGenerateRecords(t *testing.T) {
 					"myapp.internal.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "web.internal.", "myapp.docker.", "myapp.internal."}},
 			},
 		},
 		{
@@ -1413,12 +1483,14 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -1457,11 +1529,13 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -1501,6 +1575,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
@@ -1514,6 +1589,7 @@ func TestGenerateRecords(t *testing.T) {
 						{target: "web.docker.", port: 80},
 					},
 				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -1552,12 +1628,14 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
 		{
@@ -1597,6 +1675,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":     {net.ParseIP("172.17.0.2")},
@@ -1605,6 +1684,7 @@ func TestGenerateRecords(t *testing.T) {
 					"*.myapp.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "myapp.docker."}},
 			},
 		},
 		{
@@ -1643,6 +1723,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":     {net.ParseIP("172.17.0.2")},
@@ -1651,6 +1732,7 @@ func TestGenerateRecords(t *testing.T) {
 					"*.web.internal.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "web.internal."}},
 			},
 		},
 		{
@@ -1690,6 +1772,7 @@ func TestGenerateRecords(t *testing.T) {
 			expected: struct {
 				records map[string][]net.IP
 				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
 			}{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
@@ -1698,13 +1781,14 @@ func TestGenerateRecords(t *testing.T) {
 					"*.www.docker.": {net.ParseIP("172.17.0.2")},
 				},
 				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "www.docker."}},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			records, srvs := generateRecords(ctx, tt.input)
+			records, srvs, ptrs := generateRecords(ctx, tt.input)
 
 			// Check records
 			if len(records) != len(tt.expected.records) {
@@ -1764,6 +1848,37 @@ func TestGenerateRecords(t *testing.T) {
 				for i, expectedSrv := range expectedSrvs {
 					if actualSrvs[i].target != expectedSrv.target || actualSrvs[i].port != expectedSrv.port {
 						t.Errorf("expected SRV %+v for %s at index %d, got %+v", expectedSrv, srvName, i, actualSrvs[i])
+					}
+				}
+			}
+
+			// Check PTR records
+			if len(ptrs) != len(tt.expected.ptrs) {
+				t.Errorf("expected %d PTR records, got %d", len(tt.expected.ptrs), len(ptrs))
+				for arpa := range ptrs {
+					if _, ok := tt.expected.ptrs[arpa]; !ok {
+						t.Errorf("unexpected PTR record: %s", arpa)
+					}
+				}
+				for arpa := range tt.expected.ptrs {
+					if _, ok := ptrs[arpa]; !ok {
+						t.Errorf("missing PTR record: %s", arpa)
+					}
+				}
+			}
+			for arpa, expectedFqdns := range tt.expected.ptrs {
+				actualFqdns, ok := ptrs[arpa]
+				if !ok {
+					t.Errorf("expected PTR record for %s, not found", arpa)
+					continue
+				}
+				if len(actualFqdns) != len(expectedFqdns) {
+					t.Errorf("expected %d FQDNs for %s, got %d", len(expectedFqdns), arpa, len(actualFqdns))
+					continue
+				}
+				for i, expectedFqdn := range expectedFqdns {
+					if actualFqdns[i] != expectedFqdn {
+						t.Errorf("expected FQDN %s for %s at index %d, got %s", expectedFqdn, arpa, i, actualFqdns[i])
 					}
 				}
 			}

--- a/integration_test.go
+++ b/integration_test.go
@@ -89,6 +89,7 @@ func setupIntegrationDocker(t *testing.T, networks []string) (*Docker, *client.C
 		networks:    networks,
 		records:     make(map[string][]net.IP),
 		srvs:        make(map[string][]srvRecord),
+		ptrs:        make(map[string][]string),
 	}
 
 	return d, cli
@@ -594,6 +595,11 @@ func TestIntegrationSyncMetrics(t *testing.T) {
 		t.Errorf("expected srv_records_total >= 1, got %f", srvRecords)
 	}
 
+	ptrRecords := testutil.ToFloat64(ptrRecordsCount)
+	if ptrRecords < 1 {
+		t.Errorf("expected ptr_records_total >= 1, got %f", ptrRecords)
+	}
+
 	containers := testutil.ToFloat64(containersCount)
 	if containers < 1 {
 		t.Errorf("expected containers_total >= 1, got %f", containers)
@@ -800,5 +806,93 @@ func TestIntegrationWildcardExactPrecedence(t *testing.T) {
 	exactA := exactResp.Answer[0].(*dns.A)
 	if !a.A.Equal(exactA.A) {
 		t.Errorf("expected exact match IP %s, got %s (wildcard may have taken precedence)", exactA.A, a.A)
+	}
+}
+
+func TestIntegrationPTRRecord(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	// First, get the container's IP via A record
+	fqdn := name + ".docker."
+	resp, _, err := queryDNS(t, d, fqdn, dns.TypeA)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s: %v", fqdn, err)
+	}
+	if resp == nil || len(resp.Answer) == 0 {
+		t.Fatalf("expected A record for %s, got none", fqdn)
+	}
+
+	a := resp.Answer[0].(*dns.A)
+	ip := a.A.String()
+
+	// Compute the reverse ARPA name
+	arpa, err := dns.ReverseAddr(ip)
+	if err != nil {
+		t.Fatalf("Failed to compute reverse address for %s: %v", ip, err)
+	}
+
+	// Query the PTR record
+	ptrResp, _, err := queryDNS(t, d, arpa, dns.TypePTR)
+	if err != nil {
+		t.Fatalf("ServeDNS error for PTR %s: %v", arpa, err)
+	}
+	if ptrResp == nil || len(ptrResp.Answer) == 0 {
+		t.Fatalf("expected PTR record for %s, got none", arpa)
+	}
+
+	ptr, ok := ptrResp.Answer[0].(*dns.PTR)
+	if !ok {
+		t.Fatalf("expected PTR record, got %T", ptrResp.Answer[0])
+	}
+
+	if ptr.Ptr != fqdn {
+		t.Errorf("expected PTR target %s, got %s", fqdn, ptr.Ptr)
+	}
+}
+
+func TestIntegrationPTRAfterRemoval(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	containerID := createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	// Get the container's IP
+	fqdn := name + ".docker."
+	resp, _, _ := queryDNS(t, d, fqdn, dns.TypeA)
+	if resp == nil || len(resp.Answer) == 0 {
+		t.Fatalf("expected A record for %s, got none", fqdn)
+	}
+	a := resp.Answer[0].(*dns.A)
+	arpa, _ := dns.ReverseAddr(a.A.String())
+
+	// Verify PTR exists
+	ptrResp, _, _ := queryDNS(t, d, arpa, dns.TypePTR)
+	if ptrResp == nil || len(ptrResp.Answer) == 0 {
+		t.Fatalf("expected PTR record for %s before removal", arpa)
+	}
+
+	// Remove container and re-sync
+	_ = cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+	d.syncRecords(ctx)
+
+	// PTR should now pass to next plugin (ErrorHandler returns SERVFAIL)
+	_, rcode, _ := queryDNS(t, d, arpa, dns.TypePTR)
+	if rcode != dns.RcodeServerFailure {
+		t.Errorf("expected SERVFAIL for PTR %s after removal, got rcode %d", arpa, rcode)
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -58,6 +58,13 @@ var (
 		Name:      "srv_records_total",
 		Help:      "Number of SRV DNS record names currently tracked.",
 	})
+	// ptrRecordsCount is the number of PTR DNS record names currently tracked.
+	ptrRecordsCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "ptr_records_total",
+		Help:      "Number of PTR DNS record names currently tracked.",
+	})
 	// connectedGauge indicates whether the plugin is connected to the Docker daemon.
 	connectedGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,

--- a/setup.go
+++ b/setup.go
@@ -23,6 +23,7 @@ func setup(c *caddy.Controller) error {
 		maxBackoff:  60 * time.Second,
 		records:     make(map[string][]net.IP),
 		srvs:        make(map[string][]srvRecord),
+		ptrs:        make(map[string][]string),
 		ttl:         DefaultTTL,
 		zones:       []string{"docker."},
 	}


### PR DESCRIPTION
## Summary

- Automatically generate PTR records from forward A/AAAA records, enabling reverse DNS lookups (`dig -x <ip>`) for container IPs
- Support both IPv4 (`in-addr.arpa`) and IPv6 (`ip6.arpa`) reverse zones
- Handle PTR queries before the zone check in ServeDNS since reverse zones are outside configured zones; unknown IPs pass to the next plugin
- Add `coredns_docker_ptr_records_total` Prometheus metric
- Wildcard FQDNs are excluded from PTR records

Closes #47