### PR TITLE
fix: track NXDOMAIN and NODATA responses in request counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If monitoring is enabled (via the *prometheus* directive) the following metrics 
 - `coredns_docker_failed_requests_total{server}` - Counter of DNS requests failed.
 - `coredns_docker_request_duration_seconds{server, type}` - Histogram of DNS request durations in seconds. The `type` label indicates the query type (e.g., `A`, `AAAA`, `SRV`).
 - `coredns_docker_stale_requests_total{server}` - Counter of DNS requests served from stale data during Docker daemon disconnect.
+- `coredns_docker_fallthrough_requests_total{server}` - Counter of DNS requests passed to the next plugin via fallthrough.
 - `coredns_docker_last_sync_timestamp_seconds` - Unix timestamp of the last successful record sync from Docker. This can be used to monitor how fresh the plugin's data is.
 - `coredns_docker_records_total` - Number of A/AAAA DNS record names currently tracked.
 - `coredns_docker_srv_records_total` - Number of SRV DNS record names currently tracked.

--- a/docker.go
+++ b/docker.go
@@ -78,6 +78,7 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 
 		if !ptrOk {
 			log.Debugf("No PTR records for %s, passing to next plugin", qname)
+			requestFallthroughCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 			return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
 		}
 
@@ -120,6 +121,7 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	zone := plugin.Zones(d.zones).Matches(qname)
 	if zone == "" {
 		log.Debugf("Query %s not in zones [%s], passing to next plugin", qname, strings.Join(d.zones, ", "))
+		requestFallthroughCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 		return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
 	}
 
@@ -186,6 +188,7 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	if !ok && !srvOk {
 		if d.Fall.Through(qname) {
 			log.Debugf("No records found for %s, falling through to next plugin", qname)
+			requestFallthroughCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 			return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
 		}
 
@@ -198,6 +201,8 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		if err := w.WriteMsg(m); err != nil {
 			log.Errorf("Failed to write message: %v", err)
 			requestFailedCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		} else {
+			requestSuccessCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 		}
 		return dns.RcodeSuccess, nil
 	}
@@ -259,6 +264,8 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		if err := w.WriteMsg(m); err != nil {
 			log.Errorf("Failed to write message: %v", err)
 			requestFailedCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		} else {
+			requestSuccessCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 		}
 		return dns.RcodeSuccess, nil
 	}
@@ -266,6 +273,7 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	if !found {
 		if d.Fall.Through(qname) {
 			log.Debugf("No handler for type %s on %s, falling through to next plugin", dns.TypeToString[qtype], qname)
+			requestFallthroughCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 			return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
 		}
 
@@ -275,6 +283,8 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		if err := w.WriteMsg(m); err != nil {
 			log.Errorf("Failed to write message: %v", err)
 			requestFailedCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		} else {
+			requestSuccessCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 		}
 		return dns.RcodeSuccess, nil
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -970,6 +970,218 @@ func TestServeDNSStaleRequestMetric(t *testing.T) {
 	}
 }
 
+func TestServeDNSNXDOMAINSuccessMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records:   map[string][]net.IP{},
+		srvs:      map[string][]srvRecord{},
+		ptrs:      map[string][]string{},
+	}
+
+	beforeSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	beforeFailed := testutil.ToFloat64(requestFailedCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("nonexistent.docker.", dns.TypeA)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err := d.ServeDNS(context.Background(), w, m)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	afterSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	afterFailed := testutil.ToFloat64(requestFailedCount.WithLabelValues(""))
+	if afterSuccess != beforeSuccess+1 {
+		t.Errorf("expected success_requests_total to increment by 1, before=%f after=%f", beforeSuccess, afterSuccess)
+	}
+	if afterFailed != beforeFailed {
+		t.Errorf("expected failed_requests_total to not change, before=%f after=%f", beforeFailed, afterFailed)
+	}
+}
+
+func TestServeDNSNODATATypeMismatchSuccessMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records: map[string][]net.IP{
+			"web.docker.": {net.ParseIP("172.17.0.2")},
+		},
+		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
+	}
+
+	beforeSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	beforeFailed := testutil.ToFloat64(requestFailedCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("web.docker.", dns.TypeAAAA)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err := d.ServeDNS(context.Background(), w, m)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	afterSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	afterFailed := testutil.ToFloat64(requestFailedCount.WithLabelValues(""))
+	if afterSuccess != beforeSuccess+1 {
+		t.Errorf("expected success_requests_total to increment by 1, before=%f after=%f", beforeSuccess, afterSuccess)
+	}
+	if afterFailed != beforeFailed {
+		t.Errorf("expected failed_requests_total to not change, before=%f after=%f", beforeFailed, afterFailed)
+	}
+}
+
+func TestServeDNSNODATAUnsupportedTypeSuccessMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records: map[string][]net.IP{
+			"web.docker.": {net.ParseIP("172.17.0.2")},
+		},
+		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
+	}
+
+	beforeSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	beforeFailed := testutil.ToFloat64(requestFailedCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("web.docker.", dns.TypeMX)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err := d.ServeDNS(context.Background(), w, m)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	afterSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	afterFailed := testutil.ToFloat64(requestFailedCount.WithLabelValues(""))
+	if afterSuccess != beforeSuccess+1 {
+		t.Errorf("expected success_requests_total to increment by 1, before=%f after=%f", beforeSuccess, afterSuccess)
+	}
+	if afterFailed != beforeFailed {
+		t.Errorf("expected failed_requests_total to not change, before=%f after=%f", beforeFailed, afterFailed)
+	}
+}
+
+func TestServeDNSFallthroughNXDOMAINMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		Fall:      fall.Root,
+		records:   map[string][]net.IP{},
+		srvs:      map[string][]srvRecord{},
+		ptrs:      map[string][]string{},
+	}
+
+	beforeFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+	beforeSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("nonexistent.docker.", dns.TypeA)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	d.ServeDNS(context.Background(), w, m)
+
+	afterFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+	afterSuccess := testutil.ToFloat64(requestSuccessCount.WithLabelValues(""))
+	if afterFallthrough != beforeFallthrough+1 {
+		t.Errorf("expected fallthrough_requests_total to increment by 1, before=%f after=%f", beforeFallthrough, afterFallthrough)
+	}
+	if afterSuccess != beforeSuccess {
+		t.Errorf("expected success_requests_total to not change on fallthrough, before=%f after=%f", beforeSuccess, afterSuccess)
+	}
+}
+
+func TestServeDNSFallthroughUnsupportedTypeMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		Fall:      fall.Root,
+		records: map[string][]net.IP{
+			"web.docker.": {net.ParseIP("172.17.0.2")},
+		},
+		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
+	}
+
+	beforeFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("web.docker.", dns.TypeMX)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	d.ServeDNS(context.Background(), w, m)
+
+	afterFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+	if afterFallthrough != beforeFallthrough+1 {
+		t.Errorf("expected fallthrough_requests_total to increment by 1, before=%f after=%f", beforeFallthrough, afterFallthrough)
+	}
+}
+
+func TestServeDNSFallthroughZoneMissMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records:   map[string][]net.IP{},
+		srvs:      map[string][]srvRecord{},
+		ptrs:      map[string][]string{},
+	}
+
+	beforeFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("web.other.", dns.TypeA)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	d.ServeDNS(context.Background(), w, m)
+
+	afterFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+	if afterFallthrough != beforeFallthrough+1 {
+		t.Errorf("expected fallthrough_requests_total to increment by 1, before=%f after=%f", beforeFallthrough, afterFallthrough)
+	}
+}
+
+func TestServeDNSFallthroughPTRNotFoundMetric(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records:   map[string][]net.IP{},
+		srvs:      map[string][]srvRecord{},
+		ptrs:      map[string][]string{},
+	}
+
+	beforeFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+
+	m := new(dns.Msg)
+	m.SetQuestion("9.9.9.9.in-addr.arpa.", dns.TypePTR)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	d.ServeDNS(context.Background(), w, m)
+
+	afterFallthrough := testutil.ToFloat64(requestFallthroughCount.WithLabelValues(""))
+	if afterFallthrough != beforeFallthrough+1 {
+		t.Errorf("expected fallthrough_requests_total to increment by 1, before=%f after=%f", beforeFallthrough, afterFallthrough)
+	}
+}
+
 func enableDebugLog(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer

--- a/metrics.go
+++ b/metrics.go
@@ -44,6 +44,13 @@ var (
 		Name:      "stale_requests_total",
 		Help:      "Counter of DNS requests served from stale data during Docker daemon disconnect.",
 	}, []string{"server"})
+	// requestFallthroughCount is the number of DNS requests passed to the next plugin via fallthrough.
+	requestFallthroughCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "fallthrough_requests_total",
+		Help:      "Counter of DNS requests passed to the next plugin via fallthrough.",
+	}, []string{"server"})
 	// recordsCount is the number of A/AAAA DNS record names currently tracked.
 	recordsCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,


### PR DESCRIPTION
## Summary

- Increment `success_requests_total` for successfully written NXDOMAIN and NODATA responses (3 code paths in `ServeDNS` that were missing the success counter)
- Add new `fallthrough_requests_total` counter to track requests delegated to the next plugin (4 code paths: PTR not found, zone miss, NXDOMAIN fallthrough, unsupported type fallthrough)
- Add 7 unit tests covering all fixed metric paths
- Document the new `fallthrough_requests_total` metric in README

Closes #65