### PR TITLE
fix: deduplicate IPs and SRV records in record generation

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -615,38 +616,67 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 
 			names = append(names, hostnameNames...)
 
+			// Deduplicate names (case-insensitive, preserving insertion order) to
+			// avoid producing duplicate records when a container's name overlaps
+			// with its aliases or DNSNames (common on Docker 25+ user-defined
+			// networks where Aliases and DNSNames contain the container name).
+			seen := make(map[string]bool, len(names))
+			uniqueNames := names[:0]
 			for _, name := range names {
-				if name == "" {
+				lower := strings.ToLower(name)
+				if lower == "" || seen[lower] {
 					continue
 				}
+				seen[lower] = true
+				uniqueNames = append(uniqueNames, name)
+			}
+			names = uniqueNames
+
+			for _, name := range names {
 				for _, zone := range input.Zones {
 					fqdn := strings.ToLower(name + "." + zone)
 					if !strings.HasSuffix(fqdn, ".") {
 						fqdn += "."
 					}
-					newRecords[fqdn] = append(newRecords[fqdn], ip)
-					if arpaErr == nil {
+					// Dedup at the record level to also cover the edge case where
+					// two networks assign the same IP to the same container.
+					if !slices.ContainsFunc(newRecords[fqdn], ip.Equal) {
+						newRecords[fqdn] = append(newRecords[fqdn], ip)
+					}
+					if arpaErr == nil && !slices.Contains(newPtrs[arpa], fqdn) {
 						newPtrs[arpa] = append(newPtrs[arpa], fqdn)
 					}
 
 					if enableWildcard {
 						wildcardFqdn := "*." + fqdn
-						newRecords[wildcardFqdn] = append(newRecords[wildcardFqdn], ip)
+						if !slices.ContainsFunc(newRecords[wildcardFqdn], ip.Equal) {
+							newRecords[wildcardFqdn] = append(newRecords[wildcardFqdn], ip)
+						}
 					}
 
 					for srvKey, port := range containerSrvs {
 						srvName := srvKey + "." + fqdn
-						newSrvs[srvName] = append(newSrvs[srvName], srvRecord{
-							target: fqdn,
-							port:   port,
+						isDupSrv := slices.ContainsFunc(newSrvs[srvName], func(existing srvRecord) bool {
+							return existing.target == fqdn && existing.port == port
 						})
-
-						if enableWildcard {
-							wildcardSrvName := srvKey + ".*." + fqdn
-							newSrvs[wildcardSrvName] = append(newSrvs[wildcardSrvName], srvRecord{
+						if !isDupSrv {
+							newSrvs[srvName] = append(newSrvs[srvName], srvRecord{
 								target: fqdn,
 								port:   port,
 							})
+						}
+
+						if enableWildcard {
+							wildcardSrvName := srvKey + ".*." + fqdn
+							isDupWildcardSrv := slices.ContainsFunc(newSrvs[wildcardSrvName], func(existing srvRecord) bool {
+								return existing.target == fqdn && existing.port == port
+							})
+							if !isDupWildcardSrv {
+								newSrvs[wildcardSrvName] = append(newSrvs[wildcardSrvName], srvRecord{
+									target: fqdn,
+									port:   port,
+								})
+							}
 						}
 					}
 				}

--- a/e2e.bats
+++ b/e2e.bats
@@ -322,16 +322,14 @@ assert_output_contains() {
     alpine sleep 3600
 
   # Wait for alias record to appear
-  # On Docker 25+ user-defined networks, Aliases and DNSNames overlap
-  # causing duplicate IPs in dig output, so check first line only
   run wait_for_record "myalias.${COREDNS_ZONE}"
   assert_success
-  [[ "${output%%$'\n'*}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
+  [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
 
   # Also verify the container name itself resolves
   run wait_for_record "coredns-e2e-aliased.${COREDNS_ZONE}"
   assert_success
-  [[ "${output%%$'\n'*}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
+  [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
 
   docker rm -f coredns-e2e-aliased
 }

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -1784,6 +1784,289 @@ func TestGenerateRecords(t *testing.T) {
 				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "www.docker."}},
 			},
 		},
+		{
+			name: "container name overlaps with alias (dedup)",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										Aliases:   []string{"web", "api"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+					"api.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "api.docker."}},
+			},
+		},
+		{
+			name: "container name overlaps with DNSNames (dedup)",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										DNSNames:  []string{"web", "abc123"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.":    {net.ParseIP("172.17.0.2")},
+					"abc123.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "abc123.docker."}},
+			},
+		},
+		{
+			name: "alias and DNSNames both overlap with container name (dedup)",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										Aliases:   []string{"web"},
+										DNSNames:  []string{"web", "WEB"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
+		{
+			name: "SRV dedup when name overlaps with alias",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/srv._tcp._http": "8080",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										Aliases:   []string{"web"},
+										DNSNames:  []string{"web"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{
+					"_http._tcp.web.docker.": {{target: "web.docker.", port: 8080}},
+				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
+		{
+			name: "wildcard dedup when name overlaps with alias",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/wildcard":       "true",
+									"com.dokku.coredns-docker/srv._tcp._http": "8080",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										Aliases:   []string{"web"},
+										DNSNames:  []string{"web"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.":   {net.ParseIP("172.17.0.2")},
+					"*.web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{
+					"_http._tcp.web.docker.":   {{target: "web.docker.", port: 8080}},
+					"_http._tcp.*.web.docker.": {{target: "web.docker.", port: 8080}},
+				},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
+		{
+			name: "multi-network same IP deduplicated",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+									"custom": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				Networks:    []string{"bridge", "custom"},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #53.

Containers on Docker 25+ user-defined networks populate both `Aliases` and `DNSNames` with the container name itself, so the `names` slice built inside `generateRecords` frequently contained duplicate entries. This produced duplicate A, SRV, PTR, and wildcard records for the same FQDN/IP pair.

The fix has two layers:

1. Deduplicate the `names` slice case-insensitively while preserving insertion order (container name first, then aliases, then DNSNames, etc.). This eliminates the common source of duplication before the inner loop.
2. Guard each record append with `slices.ContainsFunc` / `slices.Contains`. This also handles the edge case where two networks assign the same IP to the same container (using `net.IP.Equal` so IPv4-mapped IPv6 addresses are collapsed correctly).

The prior e2e workaround in `e2e.bats` (checking only the first line of `dig` output because duplicates were expected) has been removed now that the underlying issue is fixed.