### PR TITLE
feat: add host_mode option to resolve records to host bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,76 @@ When a PTR query does not match any known container IP, it is passed to the next
 dig -x 172.17.0.2 @127.0.0.1 -p 1053
 ```
 
+### Host Mode
+
+By default, the plugin resolves container names to the container's internal network IP address (e.g. `172.17.0.2`). These IPs are only reachable from inside the Docker network, which is a problem when CoreDNS is running **outside** Docker (a common setup on macOS or when CoreDNS runs directly on the host in a development environment).
+
+Enabling `host_mode` switches the plugin to use each container's **host port bindings** (`-p` / `--publish`) as the source of A/AAAA and SRV records. The container's internal IP is no longer used.
+
+**Enable it in your Corefile:**
+
+```text
+docker.localhost:1053 {
+    docker {
+        zone docker.localhost
+        host_mode
+    }
+}
+```
+
+**What changes when `host_mode` is enabled:**
+
+- **A/AAAA records** use the host IP from each port binding instead of the container's internal network IP.
+- **SRV records** report the **host port** (e.g. `8080`), not the container port (e.g. `80`).
+- If an SRV label specifies a container port that has no matching host binding, that label is skipped (other labels still apply; there is no silent fallback to a different service name).
+- If a container has **no** SRV labels, the plugin falls back to generating SRV records from the container's bound ports — one SRV per binding's host port.
+- Containers with **no** host port bindings produce **no records** in host mode, because they are not reachable from the host.
+- Names (container name, network aliases, DNS names, Docker Compose `project.service`, and `hostname` labels) are unioned across all selected networks, because in host mode all records point at the same host.
+
+**Wildcard host IP normalization:**
+
+Docker often binds to wildcard addresses (`0.0.0.0` or `::`) to accept connections on every interface. These are not usable as record values, so the plugin normalizes them to the corresponding loopback address:
+
+- `0.0.0.0` (or empty) → `127.0.0.1`
+- `::` → `::1`
+
+Bindings to a specific host IP (e.g. `192.168.1.10`) are used as-is.
+
+**PTR records in host mode:**
+
+PTR (reverse DNS) records are **off by default** in host mode. Multiple containers often share a host IP (especially when bound to loopback), which would make reverse lookups return a noisy list of every container bound to that address.
+
+To opt back in, add the `ptr` argument:
+
+```text
+docker.localhost:1053 in-addr.arpa:1053 ip6.arpa:1053 {
+    docker {
+        zone docker.localhost
+        host_mode ptr
+    }
+}
+```
+
+With `host_mode ptr` enabled, a reverse lookup for a host IP will return the FQDNs of every container bound to it.
+
+**Example:**
+
+Start a container with a published port:
+
+```bash
+docker run -d --name web -p 127.0.0.1:18080:80 nginx
+```
+
+With `host_mode` enabled, resolution becomes:
+
+```bash
+dig web.docker.localhost @127.0.0.1 -p 1053
+# → 127.0.0.1
+
+dig _tcp._tcp.web.docker.localhost @127.0.0.1 -p 1053 SRV
+# → 10 10 18080 web.docker.localhost.
+```
+
 ## Compilation
 
 To build coredns with this plugin enabled, run the following command in this repository:
@@ -221,6 +291,7 @@ A binary will be created at `bin/coredns`.
 ```text
 docker {
     fallthrough [ZONES...]
+    host_mode [ptr]
     label_prefix PREFIX
     max_backoff DURATION
     networks NETWORK...
@@ -230,6 +301,8 @@ docker {
 ```
 
 - `fallthrough` **[ZONES...]** - If a query matches the plugin's zone but no record is found, pass the query to the next plugin instead of returning NXDOMAIN. If **ZONES** are specified, only queries for names within those zones will fall through. If no zones are given, all unmatched queries fall through. By default, the plugin returns NXDOMAIN for unknown names. Use this when composing with other plugins that serve the same zone (e.g., `file` as a fallback for static records).
+
+- `host_mode` **[ptr]** - Resolve container names to their host-bound IP addresses and host ports instead of the container's internal network IP. See [Host Mode](#host-mode) for details. Pass the optional `ptr` argument to also emit PTR records for host IPs (off by default).
 
 - `zone` is the domain (or domains) for which the plugin will respond. Multiple zones can be specified separated by spaces. Defaults to `docker.` and cannot be empty.
 

--- a/docker.go
+++ b/docker.go
@@ -44,6 +44,8 @@ type Docker struct {
 	labelPrefix string
 	maxBackoff  time.Duration
 	networks    []string
+	hostMode    bool
+	hostModePTR bool
 
 	mu           sync.RWMutex
 	records      map[string][]net.IP
@@ -402,6 +404,8 @@ func (d *Docker) syncRecords(ctx context.Context) {
 		Inspector:   d.client,
 		LabelPrefix: d.labelPrefix,
 		Networks:    d.networks,
+		HostMode:    d.hostMode,
+		HostModePTR: d.hostModePTR,
 	})
 
 	d.mu.Lock()
@@ -436,6 +440,14 @@ type GenerateRecordsInput struct {
 	LabelPrefix string
 	// Networks is the list of networks to generate records for.
 	Networks []string
+	// HostMode enables host-bound IP/port resolution instead of container IPs.
+	// When true, A/AAAA and SRV records are derived from each container's
+	// published host port bindings (NetworkSettings.Ports).
+	HostMode bool
+	// HostModePTR enables PTR record emission while HostMode is active.
+	// Off by default because multiple containers may share a host IP
+	// (especially the loopback fallback), making reverse lookups noisy.
+	HostModePTR bool
 }
 
 // generateRecords generates the records for the containers.
@@ -541,6 +553,214 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 		srvPrefix := input.LabelPrefix + "/srv."
 		if input.LabelPrefix == "" {
 			srvPrefix = "srv."
+		}
+
+		if input.HostMode {
+			// In host mode, IPs and ports come from the container's host port
+			// bindings (NetworkSettings.Ports) rather than its internal network
+			// IP. This is for setups where CoreDNS runs outside Docker and the
+			// container networks aren't directly reachable.
+			type hostBinding struct {
+				ip   net.IP
+				port uint16
+			}
+
+			// Collect bindings keyed by container port spec (e.g. "80/tcp").
+			bindingsByPort := make(map[string][]hostBinding)
+			var uniqueHostIPs []net.IP
+			seenHostIP := make(map[string]bool)
+			for portSpec, bindings := range inspect.NetworkSettings.Ports {
+				for _, b := range bindings {
+					hostIPStr := b.HostIP
+					if hostIPStr == "" || hostIPStr == "0.0.0.0" {
+						hostIPStr = "127.0.0.1"
+					} else if hostIPStr == "::" {
+						hostIPStr = "::1"
+					}
+					ip := net.ParseIP(hostIPStr)
+					if ip == nil {
+						log.Debugf("Container %s has unparseable host IP %q for port %s", c.ID, b.HostIP, portSpec)
+						continue
+					}
+					hp, err := strconv.Atoi(b.HostPort)
+					if err != nil || hp < 1 || hp > 65535 {
+						log.Debugf("Container %s has invalid host port %q for port %s", c.ID, b.HostPort, portSpec)
+						continue
+					}
+					portStr := string(portSpec)
+					bindingsByPort[portStr] = append(bindingsByPort[portStr], hostBinding{
+						ip:   ip,
+						port: uint16(hp),
+					})
+					key := ip.String()
+					if !seenHostIP[key] {
+						seenHostIP[key] = true
+						uniqueHostIPs = append(uniqueHostIPs, ip)
+					}
+				}
+			}
+
+			if len(uniqueHostIPs) == 0 {
+				log.Debugf("Container %s has no host port bindings, skipping in host mode", c.ID)
+				continue
+			}
+
+			// Deterministic IP ordering so record output is stable.
+			sort.Slice(uniqueHostIPs, func(i, j int) bool {
+				return uniqueHostIPs[i].String() < uniqueHostIPs[j].String()
+			})
+
+			// In host mode there is only one logical destination, so union
+			// names across all selected networks.
+			names := []string{baseName}
+			for _, ne := range networksToProcess {
+				names = append(names, ne.settings.Aliases...)
+				names = append(names, ne.settings.DNSNames...)
+			}
+			if project != "" && service != "" {
+				names = append(names, project+"."+service)
+			}
+			names = append(names, hostnameNames...)
+
+			// Deduplicate names (same rules as the default path).
+			seen := make(map[string]bool, len(names))
+			uniqueNames := names[:0]
+			for _, name := range names {
+				lower := strings.ToLower(name)
+				if lower == "" || seen[lower] {
+					continue
+				}
+				seen[lower] = true
+				uniqueNames = append(uniqueNames, name)
+			}
+			names = uniqueNames
+
+			// Build host-mode SRV entries from labels, translating each label's
+			// container port into its bound host port(s). Multiple bindings for
+			// the same container port produce multiple SRV records.
+			hostSrvs := make(map[string][]uint16)
+			hasSrvLabel := false
+			for k, v := range inspect.Config.Labels {
+				if !strings.HasPrefix(k, srvPrefix) {
+					continue
+				}
+				parts := strings.Split(strings.TrimPrefix(k, srvPrefix), ".")
+				if len(parts) != 2 {
+					log.Debugf("Container %s has invalid SRV label %s", c.ID, k)
+					continue
+				}
+				containerPort, err := strconv.Atoi(v)
+				if err != nil {
+					log.Debugf("Container %s has invalid SRV port %s", c.ID, v)
+					continue
+				}
+				if containerPort < 1 || containerPort > 65535 {
+					log.Debugf("Container %s has SRV port %d not in valid range 1-65535", c.ID, containerPort)
+					continue
+				}
+				hasSrvLabel = true
+				// parts[0] = "_tcp"/"_udp", parts[1] = "_http" etc.
+				proto := strings.TrimPrefix(strings.ToLower(parts[0]), "_")
+				lookup := strconv.Itoa(containerPort) + "/" + proto
+				bindingsForPort, ok := bindingsByPort[lookup]
+				if !ok || len(bindingsForPort) == 0 {
+					log.Debugf("Container %s has SRV label %s=%d but no host binding for %s in host mode", c.ID, k, containerPort, lookup)
+					continue
+				}
+				srvKey := strings.ToLower(parts[1] + "." + parts[0])
+				for _, b := range bindingsForPort {
+					hostSrvs[srvKey] = append(hostSrvs[srvKey], b.port)
+				}
+			}
+
+			// Fallback: if no SRV labels were present at all, derive SRV
+			// records from the bound port specs themselves, mirroring the
+			// default code path but using host ports.
+			if !hasSrvLabel {
+				for portStr, bindings := range bindingsByPort {
+					parts := strings.Split(portStr, "/")
+					cp, err := strconv.Atoi(parts[0])
+					if err != nil {
+						log.Debugf("Container %s has invalid port %s", c.ID, portStr)
+						continue
+					}
+					if cp < 1 || cp > 65535 {
+						log.Debugf("Container %s has port %d not in valid range 1-65535", c.ID, cp)
+						continue
+					}
+					var srvKeys []string
+					if len(parts) > 1 {
+						proto := strings.ToLower(parts[1])
+						srvKeys = []string{"_" + proto + "._" + proto}
+					} else {
+						srvKeys = []string{"_tcp._tcp", "_udp._udp"}
+					}
+					for _, srvKey := range srvKeys {
+						for _, b := range bindings {
+							hostSrvs[srvKey] = append(hostSrvs[srvKey], b.port)
+						}
+					}
+				}
+			}
+
+			// Emit records for each (name, zone) pair.
+			for _, name := range names {
+				for _, zone := range input.Zones {
+					fqdn := strings.ToLower(name + "." + zone)
+					if !strings.HasSuffix(fqdn, ".") {
+						fqdn += "."
+					}
+
+					for _, ip := range uniqueHostIPs {
+						if !slices.ContainsFunc(newRecords[fqdn], ip.Equal) {
+							newRecords[fqdn] = append(newRecords[fqdn], ip)
+						}
+						if enableWildcard {
+							wildcardFqdn := "*." + fqdn
+							if !slices.ContainsFunc(newRecords[wildcardFqdn], ip.Equal) {
+								newRecords[wildcardFqdn] = append(newRecords[wildcardFqdn], ip)
+							}
+						}
+
+						if input.HostModePTR {
+							arpa, arpaErr := dns.ReverseAddr(ip.String())
+							if arpaErr == nil && !slices.Contains(newPtrs[arpa], fqdn) {
+								newPtrs[arpa] = append(newPtrs[arpa], fqdn)
+							}
+						}
+					}
+
+					for srvKey, ports := range hostSrvs {
+						srvName := srvKey + "." + fqdn
+						for _, port := range ports {
+							isDupSrv := slices.ContainsFunc(newSrvs[srvName], func(existing srvRecord) bool {
+								return existing.target == fqdn && existing.port == port
+							})
+							if !isDupSrv {
+								newSrvs[srvName] = append(newSrvs[srvName], srvRecord{
+									target: fqdn,
+									port:   port,
+								})
+							}
+
+							if enableWildcard {
+								wildcardSrvName := srvKey + ".*." + fqdn
+								isDupWildcardSrv := slices.ContainsFunc(newSrvs[wildcardSrvName], func(existing srvRecord) bool {
+									return existing.target == fqdn && existing.port == port
+								})
+								if !isDupWildcardSrv {
+									newSrvs[wildcardSrvName] = append(newSrvs[wildcardSrvName], srvRecord{
+										target: fqdn,
+										port:   port,
+									})
+								}
+							}
+						}
+					}
+				}
+			}
+
+			continue
 		}
 
 		containerSrvs := make(map[string]uint16)

--- a/e2e.bats
+++ b/e2e.bats
@@ -568,3 +568,107 @@ EOF
   run dig +short +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" -x "$container_ip"
   [[ -z "$output" ]]
 }
+
+@test "[e2e] host_mode: published port resolves to host IP and host port" {
+  local HOSTMODE_COREFILE
+  HOSTMODE_COREFILE="$(mktemp /tmp/Corefile.hostmode.XXXXXX)"
+  local HOSTMODE_PORT=15355
+  local PUBLISHED_PORT=15800
+  cat >"$HOSTMODE_COREFILE" <<EOF
+docker.localhost:${HOSTMODE_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone docker.localhost
+        ttl 10
+        networks bridge ${TEST_NETWORK}
+        host_mode
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$HOSTMODE_COREFILE" &
+  local HOSTMODE_PID=$!
+
+  # Wait for CoreDNS to become ready
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  docker run -d --name coredns-e2e-hostmode --network bridge \
+    -p "127.0.0.1:${PUBLISHED_PORT}:80" \
+    alpine sleep 3600
+
+  # A record should resolve to the published host IP.
+  run wait_for_record_on_port "coredns-e2e-hostmode.docker.localhost" "A" "$HOSTMODE_PORT"
+  assert_success
+  assert_equal "127.0.0.1" "$output"
+
+  # SRV fallback should emit a record with the published host port.
+  run dig +short +time=2 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" \
+    "_tcp._tcp.coredns-e2e-hostmode.docker.localhost" SRV
+  assert_success
+  assert_output_contains "${PUBLISHED_PORT} coredns-e2e-hostmode.docker.localhost."
+
+  # PTR should NOT resolve by default (host_mode without ptr).
+  run dig +time=2 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" -x 127.0.0.1
+  assert_success
+  assert_output_contains "status: NXDOMAIN"
+
+  # Cleanup
+  docker rm -f coredns-e2e-hostmode
+  kill "$HOSTMODE_PID" 2>/dev/null || true
+  wait "$HOSTMODE_PID" 2>/dev/null || true
+  rm -f "$HOSTMODE_COREFILE"
+}
+
+@test "[e2e] host_mode: container without published ports produces no records" {
+  local HOSTMODE_COREFILE
+  HOSTMODE_COREFILE="$(mktemp /tmp/Corefile.hostmode.XXXXXX)"
+  local HOSTMODE_PORT=15356
+  cat >"$HOSTMODE_COREFILE" <<EOF
+docker.localhost:${HOSTMODE_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone docker.localhost
+        ttl 10
+        networks bridge ${TEST_NETWORK}
+        host_mode
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$HOSTMODE_COREFILE" &
+  local HOSTMODE_PID=$!
+
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  docker run -d --name coredns-e2e-hostmode-nobind --network bridge alpine sleep 3600
+  sleep 2
+
+  run dig +time=2 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" \
+    "coredns-e2e-hostmode-nobind.docker.localhost" A
+  assert_success
+  assert_output_contains "status: NXDOMAIN"
+
+  # Cleanup
+  docker rm -f coredns-e2e-hostmode-nobind
+  kill "$HOSTMODE_PID" 2>/dev/null || true
+  wait "$HOSTMODE_PID" 2>/dev/null || true
+  rm -f "$HOSTMODE_COREFILE"
+}

--- a/e2e.bats
+++ b/e2e.bats
@@ -673,3 +673,109 @@ EOF
   wait "$HOSTMODE_PID" 2>/dev/null || true
   rm -f "$HOSTMODE_COREFILE"
 }
+
+@test "[e2e] host_mode default: PTR query returns no answer" {
+  local HOSTMODE_COREFILE
+  HOSTMODE_COREFILE="$(mktemp /tmp/Corefile.hostmode.XXXXXX)"
+  local HOSTMODE_PORT=15357
+  local PUBLISHED_PORT=15801
+  cat >"$HOSTMODE_COREFILE" <<EOF
+docker.localhost:${HOSTMODE_PORT} in-addr.arpa:${HOSTMODE_PORT} ip6.arpa:${HOSTMODE_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone docker.localhost
+        ttl 10
+        networks bridge ${TEST_NETWORK}
+        host_mode
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$HOSTMODE_COREFILE" &
+  local HOSTMODE_PID=$!
+
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  docker run -d --name coredns-e2e-hostmode-ptr-off --network bridge \
+    -p "127.0.0.1:${PUBLISHED_PORT}:80" \
+    alpine sleep 3600
+
+  # Sanity: forward resolution works, so we know the plugin has seen the container.
+  run wait_for_record_on_port "coredns-e2e-hostmode-ptr-off.docker.localhost" "A" "$HOSTMODE_PORT"
+  assert_success
+  assert_equal "127.0.0.1" "$output"
+
+  # PTR should not return an answer because host_mode without ptr skips PTR
+  # records entirely. The query reaches the plugin (in-addr.arpa is in the
+  # server block) but the plugin has no PTR entries to serve.
+  run dig +short +time=2 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" -x 127.0.0.1
+  [[ -z "$output" ]]
+
+  # Cleanup
+  docker rm -f coredns-e2e-hostmode-ptr-off
+  kill "$HOSTMODE_PID" 2>/dev/null || true
+  wait "$HOSTMODE_PID" 2>/dev/null || true
+  rm -f "$HOSTMODE_COREFILE"
+}
+
+@test "[e2e] host_mode ptr: PTR for host IP resolves to container FQDN" {
+  local HOSTMODE_COREFILE
+  HOSTMODE_COREFILE="$(mktemp /tmp/Corefile.hostmode.XXXXXX)"
+  local HOSTMODE_PORT=15358
+  local PUBLISHED_PORT=15802
+  cat >"$HOSTMODE_COREFILE" <<EOF
+docker.localhost:${HOSTMODE_PORT} in-addr.arpa:${HOSTMODE_PORT} ip6.arpa:${HOSTMODE_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone docker.localhost
+        ttl 10
+        networks bridge ${TEST_NETWORK}
+        host_mode ptr
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$HOSTMODE_COREFILE" &
+  local HOSTMODE_PID=$!
+
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  docker run -d --name coredns-e2e-hostmode-ptr-on --network bridge \
+    -p "127.0.0.1:${PUBLISHED_PORT}:80" \
+    alpine sleep 3600
+
+  # Sanity: forward resolution works first.
+  run wait_for_record_on_port "coredns-e2e-hostmode-ptr-on.docker.localhost" "A" "$HOSTMODE_PORT"
+  assert_success
+  assert_equal "127.0.0.1" "$output"
+
+  # With `host_mode ptr`, reverse resolution of the host IP should return
+  # the container's FQDN.
+  run wait_for_record_on_port "1.0.0.127.in-addr.arpa" "PTR" "$HOSTMODE_PORT"
+  assert_success
+  assert_output_contains "coredns-e2e-hostmode-ptr-on.docker.localhost."
+
+  # Cleanup
+  docker rm -f coredns-e2e-hostmode-ptr-on
+  kill "$HOSTMODE_PID" 2>/dev/null || true
+  wait "$HOSTMODE_PID" 2>/dev/null || true
+  rm -f "$HOSTMODE_COREFILE"
+}

--- a/e2e.bats
+++ b/e2e.bats
@@ -53,6 +53,12 @@ teardown_file() {
     rm -f "$COREDNS_PID_FILE"
   fi
 
+  # Kill any orphan CoreDNS instances left behind by tests that spin up
+  # a second CoreDNS (e.g. multi-zone, host_mode) and fail mid-test before
+  # reaching their own cleanup block. Without this, an orphan holds the
+  # CI job open until the overall timeout fires.
+  pkill -f "$COREDNS_BINARY" 2>/dev/null || true
+
   # Clean up test containers
   docker ps -aq --filter "name=coredns-e2e-" | xargs -r docker rm -f 2>/dev/null || true
 
@@ -615,11 +621,6 @@ EOF
     "_tcp._tcp.coredns-e2e-hostmode.docker.localhost" SRV
   assert_success
   assert_output_contains "${PUBLISHED_PORT} coredns-e2e-hostmode.docker.localhost."
-
-  # PTR should NOT resolve by default (host_mode without ptr).
-  run dig +time=2 +tries=1 @127.0.0.1 -p "$HOSTMODE_PORT" -x 127.0.0.1
-  assert_success
-  assert_output_contains "status: NXDOMAIN"
 
   # Cleanup
   docker rm -f coredns-e2e-hostmode

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -2067,6 +2067,628 @@ func TestGenerateRecords(t *testing.T) {
 				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
 			},
 		},
+		{
+			name: "host_mode basic A record with explicit host binding",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "192.168.1.10", HostPort: "8080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("192.168.1.10")},
+				},
+				srvs: map[string][]srvRecord{
+					"_tcp._tcp.web.docker.": {
+						{target: "web.docker.", port: 8080},
+					},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode wildcard host IP 0.0.0.0 normalizes to 127.0.0.1",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "0.0.0.0", HostPort: "8080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("127.0.0.1")},
+				},
+				srvs: map[string][]srvRecord{
+					"_tcp._tcp.web.docker.": {
+						{target: "web.docker.", port: 8080},
+					},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode wildcard host IP :: normalizes to ::1",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "::", HostPort: "8080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("::1")},
+				},
+				srvs: map[string][]srvRecord{
+					"_tcp._tcp.web.docker.": {
+						{target: "web.docker.", port: 8080},
+					},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode SRV label translated to host port",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/srv._tcp._http": "80",
+								},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "127.0.0.1", HostPort: "18080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("127.0.0.1")},
+				},
+				srvs: map[string][]srvRecord{
+					"_http._tcp.web.docker.": {
+						{target: "web.docker.", port: 18080},
+					},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode multiple bindings for same container port",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/srv._tcp._http": "80",
+								},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "192.168.1.10", HostPort: "8080"},
+										{HostIP: "192.168.1.11", HostPort: "9090"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					// sorted ascending by string() form
+					"web.docker.": {net.ParseIP("192.168.1.10"), net.ParseIP("192.168.1.11")},
+				},
+				srvs: map[string][]srvRecord{
+					"_http._tcp.web.docker.": {
+						{target: "web.docker.", port: 8080},
+						{target: "web.docker.", port: 9090},
+					},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode SRV label with no matching binding is skipped",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/srv._tcp._http": "80",
+								},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("443/tcp"): []nat.PortBinding{
+										{HostIP: "127.0.0.1", HostPort: "8443"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				// Label is present so fallback does NOT run; no _http SRV
+				// is emitted and no fallback _tcp._tcp is emitted either.
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("127.0.0.1")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode container with no port bindings is skipped",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode empty HostPort skipped",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "127.0.0.1", HostPort: ""},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				// empty HostPort binding is skipped -> container has no
+				// usable bindings -> no records at all.
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode unions names across multiple networks",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+											Aliases:   []string{"alpha"},
+										},
+										"custom": {
+											IPAddress: "10.0.0.2",
+											Aliases:   []string{"beta"},
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "127.0.0.1", HostPort: "18080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				Networks:    []string{"bridge", "custom"},
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.":   {net.ParseIP("127.0.0.1")},
+					"alpha.docker.": {net.ParseIP("127.0.0.1")},
+					"beta.docker.":  {net.ParseIP("127.0.0.1")},
+				},
+				srvs: map[string][]srvRecord{
+					"_tcp._tcp.web.docker.":   {{target: "web.docker.", port: 18080}},
+					"_tcp._tcp.alpha.docker.": {{target: "alpha.docker.", port: 18080}},
+					"_tcp._tcp.beta.docker.":  {{target: "beta.docker.", port: 18080}},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode wildcard label generates wildcard A and SRV",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/wildcard":       "true",
+									"com.dokku.coredns-docker/srv._tcp._http": "80",
+								},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "127.0.0.1", HostPort: "18080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.":   {net.ParseIP("127.0.0.1")},
+					"*.web.docker.": {net.ParseIP("127.0.0.1")},
+				},
+				srvs: map[string][]srvRecord{
+					"_http._tcp.web.docker.":   {{target: "web.docker.", port: 18080}},
+					"_http._tcp.*.web.docker.": {{target: "web.docker.", port: 18080}},
+				},
+				ptrs: map[string][]string{},
+			},
+		},
+		{
+			name: "host_mode with HostModePTR emits PTR records",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/wildcard": "true",
+								},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "192.168.1.10", HostPort: "8080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+				HostModePTR: true,
+			},
+			expected: struct {
+				records map[string][]net.IP
+				srvs    map[string][]srvRecord
+				ptrs    map[string][]string
+			}{
+				records: map[string][]net.IP{
+					"web.docker.":   {net.ParseIP("192.168.1.10")},
+					"*.web.docker.": {net.ParseIP("192.168.1.10")},
+				},
+				srvs: map[string][]srvRecord{
+					"_tcp._tcp.web.docker.":   {{target: "web.docker.", port: 8080}},
+					"_tcp._tcp.*.web.docker.": {{target: "web.docker.", port: 8080}},
+				},
+				// Wildcard FQDN must NOT appear in PTR records.
+				ptrs: map[string][]string{
+					mustReverseAddr("192.168.1.10"): {"web.docker."},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/integration_test.go
+++ b/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -856,6 +858,227 @@ func TestIntegrationPTRRecord(t *testing.T) {
 
 	if ptr.Ptr != fqdn {
 		t.Errorf("expected PTR target %s, got %s", fqdn, ptr.Ptr)
+	}
+}
+
+func TestIntegrationHostModeARecord(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	d.hostMode = true
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	containerID := createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		ExposedPorts: nat.PortSet{
+			nat.Port("5432/tcp"): struct{}{},
+		},
+	}, &container.HostConfig{
+		PortBindings: nat.PortMap{
+			nat.Port("5432/tcp"): []nat.PortBinding{
+				{HostIP: "127.0.0.1", HostPort: "0"},
+			},
+		},
+	}, nil)
+
+	// Inspect to discover the host port Docker assigned.
+	inspect, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Failed to inspect container: %v", err)
+	}
+	bindings := inspect.NetworkSettings.Ports[nat.Port("5432/tcp")]
+	if len(bindings) == 0 {
+		t.Fatalf("expected at least one binding for 5432/tcp, got none")
+	}
+	hostPortStr := bindings[0].HostPort
+	if hostPortStr == "" {
+		t.Fatalf("expected non-empty HostPort, got empty")
+	}
+
+	d.syncRecords(ctx)
+
+	fqdn := name + ".docker."
+	resp, _, err := queryDNS(t, d, fqdn, dns.TypeA)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s: %v", fqdn, err)
+	}
+	if resp == nil || len(resp.Answer) == 0 {
+		t.Fatalf("expected A record for %s in host mode, got none", fqdn)
+	}
+	a, ok := resp.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected A record, got %T", resp.Answer[0])
+	}
+	if a.A.String() != "127.0.0.1" {
+		t.Errorf("expected host IP 127.0.0.1 in host mode, got %s", a.A.String())
+	}
+
+	// SRV fallback should emit a _tcp._tcp record pointing at the host port.
+	srvQname := "_tcp._tcp." + fqdn
+	srvResp, _, err := queryDNS(t, d, srvQname, dns.TypeSRV)
+	if err != nil {
+		t.Fatalf("ServeDNS error for SRV %s: %v", srvQname, err)
+	}
+	if srvResp == nil || len(srvResp.Answer) == 0 {
+		t.Fatalf("expected SRV record for %s in host mode, got none", srvQname)
+	}
+	srv, ok := srvResp.Answer[0].(*dns.SRV)
+	if !ok {
+		t.Fatalf("expected SRV record, got %T", srvResp.Answer[0])
+	}
+	if strconv.Itoa(int(srv.Port)) != hostPortStr {
+		t.Errorf("expected SRV host port %s, got %d", hostPortStr, srv.Port)
+	}
+}
+
+func TestIntegrationHostModeSRVLabel(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	d.hostMode = true
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	containerID := createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			"com.dokku.coredns-docker/srv._tcp._http": "80",
+		},
+		ExposedPorts: nat.PortSet{
+			nat.Port("80/tcp"): struct{}{},
+		},
+	}, &container.HostConfig{
+		PortBindings: nat.PortMap{
+			nat.Port("80/tcp"): []nat.PortBinding{
+				{HostIP: "127.0.0.1", HostPort: "0"},
+			},
+		},
+	}, nil)
+
+	inspect, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Failed to inspect container: %v", err)
+	}
+	bindings := inspect.NetworkSettings.Ports[nat.Port("80/tcp")]
+	if len(bindings) == 0 {
+		t.Fatalf("expected at least one binding for 80/tcp, got none")
+	}
+	hostPortStr := bindings[0].HostPort
+
+	d.syncRecords(ctx)
+
+	srvQname := "_http._tcp." + name + ".docker."
+	resp, _, err := queryDNS(t, d, srvQname, dns.TypeSRV)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s: %v", srvQname, err)
+	}
+	if resp == nil || len(resp.Answer) == 0 {
+		t.Fatalf("expected SRV record for %s in host mode, got none", srvQname)
+	}
+	srv, ok := resp.Answer[0].(*dns.SRV)
+	if !ok {
+		t.Fatalf("expected SRV record, got %T", resp.Answer[0])
+	}
+	if strconv.Itoa(int(srv.Port)) != hostPortStr {
+		t.Errorf("expected SRV host port %s, got %d", hostPortStr, srv.Port)
+	}
+}
+
+func TestIntegrationHostModeNoBindings(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	d.hostMode = true
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	fqdn := name + ".docker."
+	resp, _, err := queryDNS(t, d, fqdn, dns.TypeA)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s: %v", fqdn, err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if resp.Rcode != dns.RcodeNameError {
+		t.Errorf("expected NXDOMAIN for container without bindings in host mode, got rcode %d", resp.Rcode)
+	}
+}
+
+func TestIntegrationHostModePTRDefault(t *testing.T) {
+	// By default host_mode does not emit PTR records.
+	d, cli := setupIntegrationDocker(t, nil)
+	d.hostMode = true
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		ExposedPorts: nat.PortSet{
+			nat.Port("80/tcp"): struct{}{},
+		},
+	}, &container.HostConfig{
+		PortBindings: nat.PortMap{
+			nat.Port("80/tcp"): []nat.PortBinding{
+				{HostIP: "127.0.0.1", HostPort: "0"},
+			},
+		},
+	}, nil)
+
+	d.syncRecords(ctx)
+
+	arpa, _ := dns.ReverseAddr("127.0.0.1")
+	_, rcode, _ := queryDNS(t, d, arpa, dns.TypePTR)
+	if rcode != dns.RcodeServerFailure {
+		// With no PTR records stored, the plugin falls through to the
+		// test ErrorHandler which returns SERVFAIL.
+		t.Errorf("expected PTR for %s to pass to next plugin (SERVFAIL) in default host mode, got rcode %d", arpa, rcode)
+	}
+}
+
+func TestIntegrationHostModePTREnabled(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	d.hostMode = true
+	d.hostModePTR = true
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		ExposedPorts: nat.PortSet{
+			nat.Port("80/tcp"): struct{}{},
+		},
+	}, &container.HostConfig{
+		PortBindings: nat.PortMap{
+			nat.Port("80/tcp"): []nat.PortBinding{
+				{HostIP: "127.0.0.1", HostPort: "0"},
+			},
+		},
+	}, nil)
+
+	d.syncRecords(ctx)
+
+	arpa, _ := dns.ReverseAddr("127.0.0.1")
+	resp, _, err := queryDNS(t, d, arpa, dns.TypePTR)
+	if err != nil {
+		t.Fatalf("ServeDNS error for PTR %s: %v", arpa, err)
+	}
+	if resp == nil || len(resp.Answer) == 0 {
+		t.Fatalf("expected PTR record for %s with host_mode ptr, got none", arpa)
+	}
+	ptr, ok := resp.Answer[0].(*dns.PTR)
+	if !ok {
+		t.Fatalf("expected PTR record, got %T", resp.Answer[0])
+	}
+	expected := name + ".docker."
+	if ptr.Ptr != expected {
+		t.Errorf("expected PTR target %s, got %s", expected, ptr.Ptr)
 	}
 }
 

--- a/setup.go
+++ b/setup.go
@@ -30,8 +30,8 @@ func setup(c *caddy.Controller) error {
 	if err := parse(c, d); err != nil {
 		return plugin.Error(pluginName, err)
 	}
-	log.Debugf("Configuration: zones=[%s], ttl=%d, label_prefix=%q, networks=[%s], max_backoff=%s",
-		strings.Join(d.zones, ", "), d.ttl, d.labelPrefix, strings.Join(d.networks, ", "), d.maxBackoff)
+	log.Debugf("Configuration: zones=[%s], ttl=%d, label_prefix=%q, networks=[%s], max_backoff=%s, host_mode=%t, host_mode_ptr=%t",
+		strings.Join(d.zones, ", "), d.ttl, d.labelPrefix, strings.Join(d.networks, ", "), d.maxBackoff, d.hostMode, d.hostModePTR)
 
 	// Create a new Docker client.
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -105,6 +105,16 @@ func parse(c *caddy.Controller, d *Docker) error {
 				d.ttl = uint32(t)
 			case "fallthrough":
 				d.Fall.SetZonesFromArgs(c.RemainingArgs())
+			case "host_mode":
+				d.hostMode = true
+				for _, arg := range c.RemainingArgs() {
+					switch arg {
+					case "ptr":
+						d.hostModePTR = true
+					default:
+						return c.Errf("unknown host_mode option %q", arg)
+					}
+				}
 			case "zone":
 				args := c.RemainingArgs()
 				if len(args) == 0 {

--- a/setup_test.go
+++ b/setup_test.go
@@ -10,14 +10,16 @@ import (
 
 func TestParse(t *testing.T) {
 	tests := []struct {
-		input            string
-		shouldErr        bool
-		expectedTTL      uint32
-		expectedZones    []string
-		expectedPrefix   string
-		expectedBackoff  time.Duration
-		expectedNetworks []string
-		expectedFall     fall.F
+		input               string
+		shouldErr           bool
+		expectedTTL         uint32
+		expectedZones       []string
+		expectedPrefix      string
+		expectedBackoff     time.Duration
+		expectedNetworks    []string
+		expectedFall        fall.F
+		expectedHostMode    bool
+		expectedHostModePTR bool
 	}{
 		{
 			`docker`,
@@ -28,6 +30,8 @@ func TestParse(t *testing.T) {
 			60 * time.Second,
 			nil,
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -40,6 +44,8 @@ func TestParse(t *testing.T) {
 			60 * time.Second,
 			nil,
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -52,6 +58,8 @@ func TestParse(t *testing.T) {
 			60 * time.Second,
 			nil,
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -68,6 +76,8 @@ func TestParse(t *testing.T) {
 			30 * time.Second,
 			[]string{"bridge", "my-custom-network"},
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -81,6 +91,8 @@ func TestParse(t *testing.T) {
 			60 * time.Second,
 			nil,
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -93,6 +105,8 @@ func TestParse(t *testing.T) {
 			60 * time.Second,
 			nil,
 			fall.Root,
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -105,6 +119,36 @@ func TestParse(t *testing.T) {
 			60 * time.Second,
 			nil,
 			fall.F{Zones: []string{"example.org.", "test.org."}},
+			false,
+			false,
+		},
+		{
+			`docker {
+				host_mode
+			}`,
+			false,
+			DefaultTTL,
+			[]string{"docker."},
+			"com.dokku.coredns-docker",
+			60 * time.Second,
+			nil,
+			fall.F{},
+			true,
+			false,
+		},
+		{
+			`docker {
+				host_mode ptr
+			}`,
+			false,
+			DefaultTTL,
+			[]string{"docker."},
+			"com.dokku.coredns-docker",
+			60 * time.Second,
+			nil,
+			fall.F{},
+			true,
+			true,
 		},
 		{
 			`docker {
@@ -117,6 +161,8 @@ func TestParse(t *testing.T) {
 			0,
 			nil,
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -129,6 +175,8 @@ func TestParse(t *testing.T) {
 			0,
 			nil,
 			fall.F{},
+			false,
+			false,
 		},
 		{
 			`docker {
@@ -141,6 +189,22 @@ func TestParse(t *testing.T) {
 			0,
 			nil,
 			fall.F{},
+			false,
+			false,
+		},
+		{
+			`docker {
+				host_mode bogus
+			}`,
+			true,
+			0,
+			nil,
+			"",
+			0,
+			nil,
+			fall.F{},
+			false,
+			false,
 		},
 	}
 
@@ -200,6 +264,14 @@ func TestParse(t *testing.T) {
 
 		if !d.Fall.Equal(test.expectedFall) {
 			t.Errorf("Test %d: expected fall %v, got %v", i, test.expectedFall, d.Fall)
+		}
+
+		if d.hostMode != test.expectedHostMode {
+			t.Errorf("Test %d: expected hostMode %t, got %t", i, test.expectedHostMode, d.hostMode)
+		}
+
+		if d.hostModePTR != test.expectedHostModePTR {
+			t.Errorf("Test %d: expected hostModePTR %t, got %t", i, test.expectedHostModePTR, d.hostModePTR)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes dokku/coredns-docker#51.

Adds a new `host_mode` directive for setups where CoreDNS runs outside Docker and container network IPs are not directly reachable (common on macOS and host-based development environments).

When `host_mode` is enabled:

- A/AAAA records are sourced from each container's published host port bindings (`NetworkSettings.Ports`) rather than its internal network IP.
- SRV records report the bound **host port**, not the container port. SRV labels are translated by looking up each label's container port in the container's bindings.
- Containers without any usable host port bindings produce no records (they are unreachable from the host).
- Wildcard host bindings normalize per address family: `0.0.0.0` (or empty) -> `127.0.0.1`, `::` -> `::1`.
- Names (container name, aliases, DNSNames, compose project.service, hostname labels) are unioned across all selected networks since there is only one logical destination.
- PTR records are off by default because multiple containers often share a host IP. Pass `host_mode ptr` to opt in.

## Usage

```text
docker.localhost:1053 {
    docker {
        zone docker.localhost
        host_mode
    }
}
```

```bash
docker run -d --name web -p 127.0.0.1:18080:80 nginx

dig web.docker.localhost @127.0.0.1 -p 1053
# -> 127.0.0.1

dig _tcp._tcp.web.docker.localhost @127.0.0.1 -p 1053 SRV
# -> 10 10 18080 web.docker.localhost.
```