### PR TITLE
feat: add CNAME record support via docker labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,62 @@ This will create A records for both custom hostnames in addition to the containe
 
 If SRV labels are also configured, SRV records are generated for all names including custom hostnames.
 
+### CNAME Records via Docker Labels
+
+To alias a container to an external domain, add a label in the format:
+
+```text
+[LABEL_PREFIX]/cname=[TARGET]
+```
+
+Where:
+
+- `LABEL_PREFIX` is the value of the `label_prefix` option (defaults to `com.dokku.coredns-docker`)
+- `TARGET` is the canonical name the container should alias to (e.g., `external.example.com`)
+
+When a container has a `cname` label, the plugin emits a CNAME record for **every** name the container would otherwise receive an A/AAAA record for — container name, network aliases, Docker DNS names, Docker Compose `project.service`, and any names from the `hostname` label. No A, AAAA, SRV, or PTR records are generated for that container. This is mandated by [RFC 1034 §3.6.2](https://www.rfc-editor.org/rfc/rfc1034#section-3.6.2), which disallows a CNAME name from coexisting with other record types.
+
+**Example Docker Compose configuration:**
+
+```yaml
+services:
+  web:
+    image: nginx
+    labels:
+      - "com.dokku.coredns-docker/cname=external.example.com"
+```
+
+**Example Docker run command:**
+
+```bash
+docker run -d \
+  --name web \
+  --label "com.dokku.coredns-docker/cname=external.example.com" \
+  nginx
+```
+
+This will create a CNAME record:
+
+- `web.docker.` → `external.example.com.`
+
+**Target normalization:**
+
+- If the target does not end with a trailing dot, one is appended automatically (`external.example.com` becomes `external.example.com.`).
+- The target is lower-cased at sync time.
+- An empty `cname` label is ignored and the container falls back to normal A/AAAA record generation.
+
+**Query behavior:**
+
+- A `dig CNAME web.docker` query returns the CNAME record directly.
+- A `dig A web.docker` (or `AAAA`) query also returns the CNAME record. DNS resolvers will chase the CNAME to its target on their own; the docker plugin does not resolve the target in-process, even if the target lies inside one of the configured zones.
+- Query types other than `A`, `AAAA`, `CNAME`, and `SRV` return the CNAME in the answer section as well, since RFC 1034 specifies that the CNAME record applies regardless of the query type.
+
+**Wildcard interaction:**
+
+If the `wildcard` label is also set, a wildcard CNAME (`*.name.zone.` → `TARGET`) is generated alongside the exact-match CNAME.
+
+**Use case:** A container proxies traffic to an external service (e.g., a managed database or third-party API), and applications inside your Docker network should resolve the container name to that external host without hard-coding the external domain.
+
 ### Wildcard Records
 
 To enable wildcard DNS resolution for a container, add a label in the format:
@@ -327,6 +383,7 @@ If monitoring is enabled (via the *prometheus* directive) the following metrics 
 - `coredns_docker_records_total` - Number of A/AAAA DNS record names currently tracked.
 - `coredns_docker_srv_records_total` - Number of SRV DNS record names currently tracked.
 - `coredns_docker_ptr_records_total` - Number of PTR DNS record names currently tracked.
+- `coredns_docker_cname_records_total` - Number of CNAME DNS record names currently tracked.
 - `coredns_docker_connected` - Whether the plugin is connected to the Docker daemon (1 = connected, 0 = disconnected).
 - `coredns_docker_containers_total` - Number of Docker containers currently tracked.
 - `coredns_docker_sync_duration_seconds` - Histogram of record sync durations in seconds.
@@ -372,7 +429,7 @@ When debug logging is enabled, the plugin logs messages at key decision points t
 |---|---|
 | `Query: qname=<name> qtype=<type>` | A DNS query was received with the given name and type. |
 | `Query <name> not in zones [<zones>], passing to next plugin` | The query name does not match any configured zone, so the query is forwarded to the next plugin in the chain. |
-| `Lookup results for <name>: A/AAAA records=<n>, SRV records=<n>, connected=<bool>` | Shows the number of matching records found in the internal cache and the Docker connection status. |
+| `Lookup results for <name>: A/AAAA records=<n>, SRV records=<n>, CNAME=<bool>, connected=<bool>` | Shows the number of matching records found in the internal cache, whether a CNAME entry was matched, and the Docker connection status. |
 | `Wildcard match for <name> via <wildcard>` | No exact match was found, but a wildcard record matched. The query name's leftmost label was replaced with `*` to find the match. |
 | `PTR lookup for <name>: <n> record(s), connected=<bool>` | A PTR (reverse DNS) query matched a known container IP. Shows the number of FQDNs and connection status. |
 | `No PTR records for <name>, passing to next plugin` | A PTR query did not match any known container IP, so the query is forwarded to the next plugin. |
@@ -392,7 +449,7 @@ When debug logging is enabled, the plugin logs messages at key decision points t
 | `Configuration: zones=[<zones>], ttl=<n>, label_prefix=<prefix>, networks=[<networks>], max_backoff=<duration>` | Logs the parsed plugin configuration at startup. |
 | `Connected to Docker daemon` | The plugin successfully connected (or reconnected) to the Docker daemon. |
 | `Found <n> running containers` | The number of containers discovered during a record sync. |
-| `Synced <n> records, <n> SRV records, and <n> PTR records` | The number of DNS records generated after a sync. |
+| `Synced <n> records, <n> SRV records, <n> PTR records, and <n> CNAME records` | The number of DNS records generated after a sync. |
 
 ### Readiness Checks
 
@@ -470,6 +527,27 @@ dig _http._tcp.web.docker @127.0.0.1 -p 1053 SRV
 
 ;; ANSWER SECTION:
 _http._tcp.web.docker. 30 IN SRV 10 10 80 web.docker.
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.1#1053(127.0.0.1) (UDP)
+```
+
+### CNAME record
+
+```shell
+dig web.docker @127.0.0.1 -p 1053 CNAME
+
+; <<>> DiG 9.18.1-1ubuntu1.2-Ubuntu <<>> web.docker @127.0.0.1 -p 1053 CNAME
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 33741
+;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;web.docker.  IN CNAME
+
+;; ANSWER SECTION:
+web.docker. 30 IN CNAME external.example.com.
 
 ;; Query time: 0 msec
 ;; SERVER: 127.0.0.1#1053(127.0.0.1) (UDP)

--- a/docker.go
+++ b/docker.go
@@ -51,6 +51,7 @@ type Docker struct {
 	records      map[string][]net.IP
 	srvs         map[string][]srvRecord
 	ptrs         map[string][]string // reverse-arpa FQDN -> container FQDNs
+	cnames       map[string]string   // FQDN -> canonical target (trailing dot)
 	connected    bool
 	lastSyncTime time.Time
 }
@@ -163,7 +164,8 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	d.mu.RLock()
 	ips, ok := d.records[qname]
 	srvs, srvOk := d.srvs[qname]
-	if !ok && !srvOk {
+	cnameTarget, cnameOk := d.cnames[qname]
+	if !ok && !srvOk && !cnameOk {
 		// Try wildcard: replace the first non-underscore label with *
 		// This handles both plain names (foo.web.docker. → *.web.docker.)
 		// and SRV-prefixed names (_http._tcp.foo.web.docker. → _http._tcp.*.web.docker.)
@@ -179,16 +181,17 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			wildcardName := strings.Join(wildcardLabels, ".") + "."
 			ips, ok = d.records[wildcardName]
 			srvs, srvOk = d.srvs[wildcardName]
-			if ok || srvOk {
+			cnameTarget, cnameOk = d.cnames[wildcardName]
+			if ok || srvOk || cnameOk {
 				log.Debugf("Wildcard match for %s via %s", qname, wildcardName)
 			}
 		}
 	}
 	isConnected := d.connected
 	d.mu.RUnlock()
-	log.Debugf("Lookup results for %s: A/AAAA records=%d, SRV records=%d, connected=%t", qname, len(ips), len(srvs), isConnected)
+	log.Debugf("Lookup results for %s: A/AAAA records=%d, SRV records=%d, CNAME=%t, connected=%t", qname, len(ips), len(srvs), cnameOk, isConnected)
 
-	if !ok && !srvOk {
+	if !ok && !srvOk && !cnameOk {
 		if d.Fall.Through(qname) {
 			log.Debugf("No records found for %s, falling through to next plugin", qname)
 			requestFallthroughCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
@@ -230,7 +233,22 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	}
 
 	found := false
-	if qtype == dns.TypeSRV {
+	if cnameOk {
+		// A CNAME name has no other record types (RFC 1034). Return the
+		// CNAME for any query type — the resolver will re-query for the
+		// target if it wants A/AAAA. Use a CNAME-typed header so the RR
+		// serializes correctly regardless of the original qtype.
+		m.Answer = append(m.Answer, &dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name:   state.QName(),
+				Rrtype: dns.TypeCNAME,
+				Class:  dns.ClassINET,
+				Ttl:    ttl,
+			},
+			Target: cnameTarget,
+		})
+		found = true
+	} else if qtype == dns.TypeSRV {
 		for _, srv := range srvs {
 			m.Answer = append(m.Answer, &dns.SRV{
 				Hdr:      header,
@@ -398,7 +416,7 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	}
 	log.Debugf("Found %d running containers", len(containers))
 
-	newRecords, newSrvs, newPtrs := generateRecords(ctx, GenerateRecordsInput{
+	newRecords, newSrvs, newPtrs, newCnames := generateRecords(ctx, GenerateRecordsInput{
 		Containers:  containers,
 		Zones:       d.zones,
 		Inspector:   d.client,
@@ -412,6 +430,7 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	d.records = newRecords
 	d.srvs = newSrvs
 	d.ptrs = newPtrs
+	d.cnames = newCnames
 	d.lastSyncTime = time.Now()
 	d.mu.Unlock()
 	lastSyncTimestamp.Set(float64(time.Now().Unix()))
@@ -419,8 +438,9 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	recordsCount.Set(float64(len(newRecords)))
 	srvRecordsCount.Set(float64(len(newSrvs)))
 	ptrRecordsCount.Set(float64(len(newPtrs)))
+	cnameRecordsCount.Set(float64(len(newCnames)))
 	containersCount.Set(float64(len(containers)))
-	log.Debugf("Synced %d records, %d SRV records, and %d PTR records", len(newRecords), len(newSrvs), len(newPtrs))
+	log.Debugf("Synced %d records, %d SRV records, %d PTR records, and %d CNAME records", len(newRecords), len(newSrvs), len(newPtrs), len(newCnames))
 }
 
 // ContainerInspector is an interface for inspecting containers.
@@ -451,10 +471,11 @@ type GenerateRecordsInput struct {
 }
 
 // generateRecords generates the records for the containers.
-func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[string][]net.IP, map[string][]srvRecord, map[string][]string) {
+func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[string][]net.IP, map[string][]srvRecord, map[string][]string, map[string]string) {
 	newRecords := make(map[string][]net.IP)
 	newSrvs := make(map[string][]srvRecord)
 	newPtrs := make(map[string][]string)
+	newCnames := make(map[string]string)
 
 	for _, c := range input.Containers {
 		inspect, err := input.Inspector.ContainerInspect(ctx, c.ID)
@@ -549,10 +570,75 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 		}
 		enableWildcard := inspect.Config.Labels[wildcardLabel] == "true"
 
+		// Parse cname label. If set, the container is fully aliased to the
+		// target: we emit only CNAME records for all of its names, and skip
+		// A/AAAA, SRV, and PTR records (RFC 1034 disallows a CNAME name from
+		// having other record types).
+		cnameLabel := input.LabelPrefix + "/cname"
+		if input.LabelPrefix == "" {
+			cnameLabel = "cname"
+		}
+		var containerCname string
+		if raw, ok := inspect.Config.Labels[cnameLabel]; ok {
+			trimmed := strings.TrimSpace(raw)
+			if trimmed != "" {
+				lower := strings.ToLower(trimmed)
+				if !strings.HasSuffix(lower, ".") {
+					lower += "."
+				}
+				containerCname = lower
+			}
+		}
+
 		// Add SRV records based on labels
 		srvPrefix := input.LabelPrefix + "/srv."
 		if input.LabelPrefix == "" {
 			srvPrefix = "srv."
+		}
+
+		if containerCname != "" {
+			// Union names across all selected networks (same rule as host mode),
+			// because a CNAME has no IP affinity — the destination is the
+			// external name the user asked us to alias to.
+			names := []string{baseName}
+			for _, ne := range networksToProcess {
+				names = append(names, ne.settings.Aliases...)
+				names = append(names, ne.settings.DNSNames...)
+			}
+			if project != "" && service != "" {
+				names = append(names, project+"."+service)
+			}
+			names = append(names, hostnameNames...)
+
+			seen := make(map[string]bool, len(names))
+			uniqueNames := names[:0]
+			for _, name := range names {
+				lower := strings.ToLower(name)
+				if lower == "" || seen[lower] {
+					continue
+				}
+				seen[lower] = true
+				uniqueNames = append(uniqueNames, name)
+			}
+			names = uniqueNames
+
+			for _, name := range names {
+				for _, zone := range input.Zones {
+					fqdn := strings.ToLower(name + "." + zone)
+					if !strings.HasSuffix(fqdn, ".") {
+						fqdn += "."
+					}
+					// CNAME targets are last-write-wins if two containers happen
+					// to claim the same name; same semantics as conflicting A
+					// records today.
+					newCnames[fqdn] = containerCname
+					if enableWildcard {
+						newCnames["*."+fqdn] = containerCname
+					}
+				}
+			}
+
+			continue
 		}
 
 		if input.HostMode {
@@ -904,5 +990,5 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 		}
 	}
 
-	return newRecords, newSrvs, newPtrs
+	return newRecords, newSrvs, newPtrs, newCnames
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -475,6 +475,142 @@ func TestDockerWildcard(t *testing.T) {
 	}
 }
 
+func TestDockerCNAME(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: true,
+		zones:     []string{"docker."},
+		records: map[string][]net.IP{
+			"other.docker.": {net.ParseIP("172.17.0.3")},
+		},
+		srvs: map[string][]srvRecord{},
+		ptrs: map[string][]string{},
+		cnames: map[string]string{
+			"web.docker.":     "external.example.com.",
+			"alias.docker.":   "external.example.com.",
+			"*.wild.docker.":  "external.example.com.",
+		},
+	}
+
+	var cases = []test.Case{
+		{
+			// CNAME type query returns the CNAME record.
+			Qname: "web.docker.",
+			Qtype: dns.TypeCNAME,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("web.docker.	30	IN	CNAME	external.example.com."),
+			},
+		},
+		{
+			// A query on a CNAME name returns the CNAME; resolver chases it.
+			Qname: "web.docker.",
+			Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("web.docker.	30	IN	CNAME	external.example.com."),
+			},
+		},
+		{
+			// AAAA query on a CNAME name also returns the CNAME.
+			Qname: "web.docker.",
+			Qtype: dns.TypeAAAA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("web.docker.	30	IN	CNAME	external.example.com."),
+			},
+		},
+		{
+			// Alias name also resolves to the same CNAME target.
+			Qname: "alias.docker.",
+			Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("alias.docker.	30	IN	CNAME	external.example.com."),
+			},
+		},
+		{
+			// Wildcard CNAME match.
+			Qname: "anything.wild.docker.",
+			Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("anything.wild.docker.	30	IN	CNAME	external.example.com."),
+			},
+		},
+		{
+			// Non-cname name is unaffected.
+			Qname: "other.docker.",
+			Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.A("other.docker.	30	IN	A	172.17.0.3"),
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	for i, tc := range cases {
+		r := tc.Msg()
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := d.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d (%s): expected no error, got %v", i, tc.Qname, err)
+			continue
+		}
+
+		if w.Msg == nil {
+			if tc.Rcode != dns.RcodeSuccess || len(tc.Answer) != 0 {
+				t.Errorf("Test %d (%s): nil message", i, tc.Qname)
+			}
+			continue
+		}
+
+		if err := test.SortAndCheck(w.Msg, tc); err != nil {
+			t.Errorf("Test %d (%s): %v", i, tc.Qname, err)
+		}
+	}
+}
+
+func TestDockerCNAMEStaleTTL(t *testing.T) {
+	d := &Docker{
+		Next:      test.ErrorHandler(),
+		ttl:       DefaultTTL,
+		connected: false,
+		zones:     []string{"docker."},
+		records:   map[string][]net.IP{},
+		srvs:      map[string][]srvRecord{},
+		ptrs:      map[string][]string{},
+		cnames: map[string]string{
+			"web.docker.": "external.example.com.",
+		},
+	}
+
+	tc := test.Case{
+		Qname: "web.docker.",
+		Qtype: dns.TypeCNAME,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("web.docker.	5	IN	CNAME	external.example.com."),
+		},
+	}
+
+	r := tc.Msg()
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err := d.ServeDNS(context.Background(), w, r)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if err := test.SortAndCheck(w.Msg, tc); err != nil {
+		t.Errorf("error: %v", err)
+	}
+}
+
 func TestDockerFallthrough(t *testing.T) {
 	d := &Docker{
 		Next:      test.ErrorHandler(),

--- a/e2e.bats
+++ b/e2e.bats
@@ -396,6 +396,57 @@ assert_output_contains() {
   docker rm -f coredns-e2e-hostname-srv
 }
 
+@test "[e2e] cname label: CNAME type query returns target" {
+  docker run -d --name coredns-e2e-cname --network bridge \
+    --label "com.dokku.coredns-docker/cname=external.example.com" \
+    alpine sleep 3600
+
+  # Wait for the CNAME record to become resolvable.
+  run wait_for_record "coredns-e2e-cname.${COREDNS_ZONE}" "CNAME"
+  assert_success
+  assert_equal "external.example.com." "$output"
+
+  docker rm -f coredns-e2e-cname
+}
+
+@test "[e2e] cname label: A query on cname name returns CNAME in answer" {
+  docker run -d --name coredns-e2e-cname-a --network bridge \
+    --label "com.dokku.coredns-docker/cname=external.example.com" \
+    alpine sleep 3600
+
+  # Wait for the CNAME entry to exist.
+  run wait_for_record "coredns-e2e-cname-a.${COREDNS_ZONE}" "CNAME"
+  assert_success
+
+  # An A query against the cname name should return a CNAME RR (no recursion
+  # configured, so nothing chases the target).
+  run dig +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-cname-a.${COREDNS_ZONE}" A
+  assert_success
+  assert_output_contains "status: NOERROR"
+  assert_output_contains "CNAME	external.example.com."
+
+  docker rm -f coredns-e2e-cname-a
+}
+
+@test "[e2e] cname label: no A record is generated for cname container" {
+  docker run -d --name coredns-e2e-cname-noa --network bridge \
+    --label "com.dokku.coredns-docker/cname=external.example.com" \
+    alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-cname-noa.${COREDNS_ZONE}" "CNAME"
+  assert_success
+
+  # An A-only +short response must not contain any IPv4 address — only the
+  # CNAME target string should appear. This catches any regression where the
+  # plugin double-emits A records for cname containers.
+  run dig +short @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-cname-noa.${COREDNS_ZONE}" A
+  assert_success
+  [[ ! "$output" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]
+  assert_output_contains "external.example.com."
+
+  docker rm -f coredns-e2e-cname-noa
+}
+
 @test "[e2e] network filtering: container on unmonitored network does not resolve" {
   docker network create coredns-e2e-unmonitored 2>/dev/null || true
   docker run -d --name coredns-e2e-filtered --network coredns-e2e-unmonitored alpine sleep 3600

--- a/e2e.bats
+++ b/e2e.bats
@@ -419,15 +419,17 @@ assert_output_contains() {
   assert_success
 
   # An A query against the cname name should return a CNAME RR (no recursion
-  # configured, so nothing chases the target). dig's formatted output uses
-  # whitespace that varies by version, so assert on separate substrings
-  # instead of a fixed-layout match.
-  run dig +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-cname-a.${COREDNS_ZONE}" A
+  # configured, so nothing chases the target). Use +noall +answer so dig
+  # emits just the ANSWER section in master-file format, which gives us a
+  # single line to parse regardless of dig's header/stats layout.
+  run dig +noall +answer +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" \
+    "coredns-e2e-cname-a.${COREDNS_ZONE}" A
   assert_success
-  assert_output_contains "status: NOERROR"
-  assert_output_contains "ANSWER: 1"
-  assert_output_contains "CNAME"
-  assert_output_contains "external.example.com."
+  # Expect exactly one record: a CNAME pointing at external.example.com.
+  local -a fields
+  read -ra fields <<<"$output"
+  assert_equal "CNAME" "${fields[3]}"
+  assert_equal "external.example.com." "${fields[4]}"
 
   docker rm -f coredns-e2e-cname-a
 }

--- a/e2e.bats
+++ b/e2e.bats
@@ -419,11 +419,15 @@ assert_output_contains() {
   assert_success
 
   # An A query against the cname name should return a CNAME RR (no recursion
-  # configured, so nothing chases the target).
+  # configured, so nothing chases the target). dig's formatted output uses
+  # whitespace that varies by version, so assert on separate substrings
+  # instead of a fixed-layout match.
   run dig +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-cname-a.${COREDNS_ZONE}" A
   assert_success
   assert_output_contains "status: NOERROR"
-  assert_output_contains "CNAME	external.example.com."
+  assert_output_contains "ANSWER: 1"
+  assert_output_contains "CNAME"
+  assert_output_contains "external.example.com."
 
   docker rm -f coredns-e2e-cname-a
 }

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -28,17 +28,20 @@ func mustReverseAddr(ip string) string {
 	return arpa
 }
 
+type generateRecordsExpected struct {
+	records map[string][]net.IP
+	srvs    map[string][]srvRecord
+	ptrs    map[string][]string
+	cnames  map[string]string
+}
+
 func TestGenerateRecords(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
 		name     string
 		input    GenerateRecordsInput
-		expected struct {
-			records map[string][]net.IP
-			srvs    map[string][]srvRecord
-			ptrs    map[string][]string
-		}
+		expected generateRecordsExpected
 	}{
 		{
 			name: "basic container name",
@@ -71,11 +74,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -115,11 +114,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 					"www.docker.": {net.ParseIP("172.17.0.2")},
@@ -163,11 +158,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"myproj_mysvc_1.docker.": {net.ParseIP("172.17.0.3")},
 					"myproj.mysvc.docker.":   {net.ParseIP("172.17.0.3")},
@@ -209,11 +200,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -262,11 +249,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"db.docker.": {net.ParseIP("172.17.0.3")},
 				},
@@ -315,11 +298,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"app.docker.": {net.ParseIP("172.17.0.4")},
 				},
@@ -385,11 +364,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				Networks:    []string{"bridge"},
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -430,11 +405,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -479,11 +450,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -524,11 +491,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -573,11 +536,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -622,11 +581,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -668,11 +623,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -725,11 +676,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -766,11 +713,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{},
 				srvs:    map[string][]srvRecord{},
 				ptrs:    map[string][]string{},
@@ -799,11 +742,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{},
 				srvs:    map[string][]srvRecord{},
 				ptrs:    map[string][]string{},
@@ -836,11 +775,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -877,11 +812,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				Networks:    []string{"custom"},
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("10.0.0.2")},
 				},
@@ -918,11 +849,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				Networks:    []string{"bridge", "custom"},
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2"), net.ParseIP("10.0.0.2")},
 				},
@@ -958,11 +885,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -1001,11 +924,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker.", "internal."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"web.internal.": {net.ParseIP("172.17.0.2")},
@@ -1047,11 +966,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker.", "internal."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"web.internal.": {net.ParseIP("172.17.0.2")},
@@ -1100,11 +1015,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"myapp.docker.": {net.ParseIP("172.17.0.2")},
@@ -1146,11 +1057,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":  {net.ParseIP("172.17.0.2")},
 					"app1.docker.": {net.ParseIP("172.17.0.2")},
@@ -1194,11 +1101,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":  {net.ParseIP("172.17.0.2")},
 					"app1.docker.": {net.ParseIP("172.17.0.2")},
@@ -1242,11 +1145,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -1287,11 +1186,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -1332,11 +1227,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"myapp.docker.": {net.ParseIP("172.17.0.2")},
@@ -1379,11 +1270,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"myapp.docker.": {net.ParseIP("172.17.0.2")},
@@ -1432,11 +1319,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker.", "internal."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":     {net.ParseIP("172.17.0.2")},
 					"web.internal.":   {net.ParseIP("172.17.0.2")},
@@ -1480,11 +1363,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
@@ -1526,11 +1405,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -1572,11 +1447,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
@@ -1625,11 +1496,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
@@ -1672,11 +1539,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":     {net.ParseIP("172.17.0.2")},
 					"*.web.docker.":   {net.ParseIP("172.17.0.2")},
@@ -1720,11 +1583,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker.", "internal."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":     {net.ParseIP("172.17.0.2")},
 					"*.web.docker.":   {net.ParseIP("172.17.0.2")},
@@ -1769,11 +1628,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
@@ -1816,11 +1671,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 					"api.docker.": {net.ParseIP("172.17.0.2")},
@@ -1861,11 +1712,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":    {net.ParseIP("172.17.0.2")},
 					"abc123.docker.": {net.ParseIP("172.17.0.2")},
@@ -1907,11 +1754,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -1954,11 +1797,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -2004,11 +1843,7 @@ func TestGenerateRecords(t *testing.T) {
 				Zones:       []string{"docker."},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("172.17.0.2")},
 					"*.web.docker.": {net.ParseIP("172.17.0.2")},
@@ -2055,11 +1890,7 @@ func TestGenerateRecords(t *testing.T) {
 				Networks:    []string{"bridge", "custom"},
 				LabelPrefix: "com.dokku.coredns-docker",
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("172.17.0.2")},
 				},
@@ -2107,11 +1938,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("192.168.1.10")},
 				},
@@ -2163,11 +1990,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("127.0.0.1")},
 				},
@@ -2219,11 +2042,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("::1")},
 				},
@@ -2277,11 +2096,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.": {net.ParseIP("127.0.0.1")},
 				},
@@ -2336,11 +2151,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					// sorted ascending by string() form
 					"web.docker.": {net.ParseIP("192.168.1.10"), net.ParseIP("192.168.1.11")},
@@ -2396,11 +2207,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				// Label is present so fallback does NOT run; no _http SRV
 				// is emitted and no fallback _tcp._tcp is emitted either.
 				records: map[string][]net.IP{
@@ -2442,11 +2249,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{},
 				srvs:    map[string][]srvRecord{},
 				ptrs:    map[string][]string{},
@@ -2492,11 +2295,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				// empty HostPort binding is skipped -> container has no
 				// usable bindings -> no records at all.
 				records: map[string][]net.IP{},
@@ -2550,11 +2349,7 @@ func TestGenerateRecords(t *testing.T) {
 				Networks:    []string{"bridge", "custom"},
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("127.0.0.1")},
 					"alpha.docker.": {net.ParseIP("127.0.0.1")},
@@ -2611,11 +2406,7 @@ func TestGenerateRecords(t *testing.T) {
 				LabelPrefix: "com.dokku.coredns-docker",
 				HostMode:    true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("127.0.0.1")},
 					"*.web.docker.": {net.ParseIP("127.0.0.1")},
@@ -2670,11 +2461,7 @@ func TestGenerateRecords(t *testing.T) {
 				HostMode:    true,
 				HostModePTR: true,
 			},
-			expected: struct {
-				records map[string][]net.IP
-				srvs    map[string][]srvRecord
-				ptrs    map[string][]string
-			}{
+			expected: generateRecordsExpected{
 				records: map[string][]net.IP{
 					"web.docker.":   {net.ParseIP("192.168.1.10")},
 					"*.web.docker.": {net.ParseIP("192.168.1.10")},
@@ -2689,11 +2476,410 @@ func TestGenerateRecords(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "container with cname label",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname": "external.example.com.",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				// CNAME suppresses A/AAAA/SRV/PTR.
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with cname label missing trailing dot",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname": "external.example.com",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with empty cname label falls back to A records",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname": "",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
+		{
+			name: "container with cname and hostname label uses cname for all names",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname":    "external.example.com.",
+									"com.dokku.coredns-docker/hostname": "myapp,www",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										Aliases:   []string{"alias1"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.":    "external.example.com.",
+					"alias1.docker.": "external.example.com.",
+					"myapp.docker.":  "external.example.com.",
+					"www.docker.":    "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with cname label suppresses srv labels",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname":          "external.example.com.",
+									"com.dokku.coredns-docker/srv._tcp._http": "80",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with cname and wildcard label",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname":    "external.example.com.",
+									"com.dokku.coredns-docker/wildcard": "true",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.":   "external.example.com.",
+					"*.web.docker.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with cname label and multi-zone",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname": "external.example.com.",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker.", "internal."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.":   "external.example.com.",
+					"web.internal.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with cname label and empty label prefix",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"cname": "external.example.com.",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with cname label in host mode",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname": "external.example.com.",
+								},
+							},
+							NetworkSettings: func() *container.NetworkSettings {
+								ns := &container.NetworkSettings{
+									Networks: map[string]*network.EndpointSettings{
+										"bridge": {
+											IPAddress: "172.17.0.2",
+										},
+									},
+								}
+								ns.Ports = nat.PortMap{
+									nat.Port("80/tcp"): []nat.PortBinding{
+										{HostIP: "127.0.0.1", HostPort: "18080"},
+									},
+								}
+								return ns
+							}(),
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+				HostMode:    true,
+				HostModePTR: true,
+			},
+			expected: generateRecordsExpected{
+				// Host mode: CNAME still short-circuits before host bindings are
+				// examined, so no A/AAAA/SRV/PTR records are emitted.
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.": "external.example.com.",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			records, srvs, ptrs := generateRecords(ctx, tt.input)
+			records, srvs, ptrs, cnames := generateRecords(ctx, tt.input)
 
 			// Check records
 			if len(records) != len(tt.expected.records) {
@@ -2785,6 +2971,31 @@ func TestGenerateRecords(t *testing.T) {
 					if actualFqdns[i] != expectedFqdn {
 						t.Errorf("expected FQDN %s for %s at index %d, got %s", expectedFqdn, arpa, i, actualFqdns[i])
 					}
+				}
+			}
+
+			// Check CNAME records
+			if len(cnames) != len(tt.expected.cnames) {
+				t.Errorf("expected %d CNAME records, got %d", len(tt.expected.cnames), len(cnames))
+				for fqdn := range cnames {
+					if _, ok := tt.expected.cnames[fqdn]; !ok {
+						t.Errorf("unexpected CNAME record: %s", fqdn)
+					}
+				}
+				for fqdn := range tt.expected.cnames {
+					if _, ok := cnames[fqdn]; !ok {
+						t.Errorf("missing CNAME record: %s", fqdn)
+					}
+				}
+			}
+			for fqdn, expectedTarget := range tt.expected.cnames {
+				actualTarget, ok := cnames[fqdn]
+				if !ok {
+					t.Errorf("expected CNAME record for %s, not found", fqdn)
+					continue
+				}
+				if actualTarget != expectedTarget {
+					t.Errorf("expected CNAME target %s for %s, got %s", expectedTarget, fqdn, actualTarget)
 				}
 			}
 		})

--- a/integration_test.go
+++ b/integration_test.go
@@ -92,6 +92,7 @@ func setupIntegrationDocker(t *testing.T, networks []string) (*Docker, *client.C
 		records:     make(map[string][]net.IP),
 		srvs:        make(map[string][]srvRecord),
 		ptrs:        make(map[string][]string),
+		cnames:      make(map[string]string),
 	}
 
 	return d, cli
@@ -678,6 +679,69 @@ func TestIntegrationHostnameLabel(t *testing.T) {
 	}
 	if !a2.A.Equal(containerA.A) {
 		t.Errorf("expected hostname %s to resolve to %s, got %s", hostnameFqdn2, containerA.A, a2.A)
+	}
+}
+
+func TestIntegrationCNAMELabel(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			"com.dokku.coredns-docker/cname": "external.example.com",
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	fqdn := name + ".docker."
+
+	// CNAME'd container must not appear in the A/AAAA map.
+	d.mu.RLock()
+	if _, ok := d.records[fqdn]; ok {
+		d.mu.RUnlock()
+		t.Fatalf("expected no A records for CNAME'd container %s, but found some", fqdn)
+	}
+	// The cname map must contain the FQDN with the target normalized to a
+	// trailing dot.
+	target, ok := d.cnames[fqdn]
+	d.mu.RUnlock()
+	if !ok {
+		t.Fatalf("expected CNAME entry for %s, not found", fqdn)
+	}
+	if target != "external.example.com." {
+		t.Errorf("expected CNAME target external.example.com., got %s", target)
+	}
+
+	// CNAME type query returns the CNAME answer.
+	resp, _, err := queryDNS(t, d, fqdn, dns.TypeCNAME)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s CNAME: %v", fqdn, err)
+	}
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 CNAME answer for %s, got %+v", fqdn, resp)
+	}
+	cname, ok := resp.Answer[0].(*dns.CNAME)
+	if !ok {
+		t.Fatalf("expected *dns.CNAME, got %T", resp.Answer[0])
+	}
+	if cname.Target != "external.example.com." {
+		t.Errorf("expected CNAME target external.example.com., got %s", cname.Target)
+	}
+
+	// A query on the CNAME name also returns a CNAME (resolver chases it).
+	resp, _, err = queryDNS(t, d, fqdn, dns.TypeA)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s A: %v", fqdn, err)
+	}
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 CNAME answer for %s A query, got %+v", fqdn, resp)
+	}
+	if _, ok := resp.Answer[0].(*dns.CNAME); !ok {
+		t.Errorf("expected CNAME answer for A query on CNAME name, got %T", resp.Answer[0])
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -72,6 +72,13 @@ var (
 		Name:      "ptr_records_total",
 		Help:      "Number of PTR DNS record names currently tracked.",
 	})
+	// cnameRecordsCount is the number of CNAME DNS record names currently tracked.
+	cnameRecordsCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "cname_records_total",
+		Help:      "Number of CNAME DNS record names currently tracked.",
+	})
 	// connectedGauge indicates whether the plugin is connected to the Docker daemon.
 	connectedGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,

--- a/setup.go
+++ b/setup.go
@@ -24,6 +24,7 @@ func setup(c *caddy.Controller) error {
 		records:     make(map[string][]net.IP),
 		srvs:        make(map[string][]srvRecord),
 		ptrs:        make(map[string][]string),
+		cnames:      make(map[string]string),
 		ttl:         DefaultTTL,
 		zones:       []string{"docker."},
 	}


### PR DESCRIPTION
## Summary

Adds support for emitting CNAME records from Docker labels. Containers with a
`[LABEL_PREFIX]/cname=TARGET` label are fully aliased to the target host: no
A/AAAA, SRV, or PTR records are produced (per RFC 1034 §3.6.2). The plugin
mirrors the existing A/AAAA/SRV/PTR map-based pattern — a new `cnames` map on
the `Docker` struct, populated in `generateRecords` and consulted in
`ServeDNS` ahead of the existing lookup branches.

- CNAME targets are lower-cased and trailing-dot normalized at sync time.
- Wildcard and multi-zone labels interact with CNAME the same way they do
  with A records.
- Queries of any type on a CNAME name return the CNAME in the answer
  section; the resolver chases the target on its own. In-zone CNAME targets
  are intentionally **not** resolved in-plugin.
- A new `coredns_docker_cname_records_total` gauge tracks the number of
  cname entries.

Closes #50