### PR TITLE
feat: add TXT record support via docker labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,92 @@ If the `wildcard` label is also set, a wildcard CNAME (`*.name.zone.` → `TARGE
 
 **Use case:** A container proxies traffic to an external service (e.g., a managed database or third-party API), and applications inside your Docker network should resolve the container name to that external host without hard-coding the external domain.
 
+### TXT Records via Docker Labels
+
+To attach TXT records to a container, add labels in one of two formats:
+
+```text
+[LABEL_PREFIX]/txt=[VALUE]
+[LABEL_PREFIX]/txt.[KEY]=[VALUE]
+```
+
+Where:
+
+- `LABEL_PREFIX` is the value of the `label_prefix` option (defaults to `com.dokku.coredns-docker`)
+- The simple form (`txt=...`) attaches a TXT record to the container's own FQDN.
+- The keyed form (`txt.KEY=...`) attaches a TXT record to `KEY.<container>.<zone>`.
+- `VALUE` is the TXT record's text data.
+
+**Example Docker Compose configuration:**
+
+```yaml
+services:
+  web:
+    image: nginx
+    labels:
+      - "com.dokku.coredns-docker/txt=v=spf1 -all"
+      - "com.dokku.coredns-docker/txt.info=version=1.0.0"
+      - "com.dokku.coredns-docker/txt._acme-challenge=deadbeef"
+```
+
+**Example Docker run command:**
+
+```bash
+docker run -d \
+  --name web \
+  --label "com.dokku.coredns-docker/txt=v=spf1 -all" \
+  --label "com.dokku.coredns-docker/txt._acme-challenge=deadbeef" \
+  nginx
+```
+
+This creates TXT records:
+
+- `web.docker.` → `"v=spf1 -all"`
+- `info.web.docker.` → `"version=1.0.0"`
+- `_acme-challenge.web.docker.` → `"deadbeef"`
+
+**Value semantics:**
+
+- Multiple TXT labels on the same container accumulate: each contributes one TXT RR.
+- The keyed segment is lowercased when building the FQDN; `txt.Info=...` and `txt.info=...` produce the same record.
+- An empty label value is valid (e.g. `txt.empty=` yields `"" ` — RFC 1035 permits empty character-strings).
+- TXT values longer than 255 bytes are automatically split into multiple 255-byte `character-string`s on the wire by the DNS library; no manual chunking is required.
+- A bare `txt.` label (trailing dot, no key) is ignored.
+
+**Quoted-form values (multi-string / escape sequences):**
+
+If the label value starts with a double-quote (`"`), it is parsed as RFC 1035 master-file TXT rdata. This lets a single label produce a TXT record containing multiple `character-string`s and lets you embed quotes or backslashes via standard escapes.
+
+Examples:
+
+- `com.dokku.coredns-docker/txt="hello" "world"` → one TXT RR with two character-strings, `"hello"` and `"world"`.
+- `com.dokku.coredns-docker/txt="say \"hi\""` → one TXT RR whose single character-string is `say "hi"` (escaped quotes collapse to literal quotes).
+- `com.dokku.coredns-docker/txt="path\\to\\file"` → one TXT RR whose character-string is `path\to\file` (escaped backslashes collapse to literal backslashes).
+- `com.dokku.coredns-docker/txt="helloA"` and `com.dokku.coredns-docker/txt="hello\065"` produce identical wire bytes (`\065` decimal ⇒ byte `A`).
+
+If the value starts with `"` but is not a well-formed master-file string (for example an unterminated quote), the plugin logs a debug message and falls back to storing the raw label value verbatim as a single character-string.
+
+Label values that do **not** start with `"` bypass master-file parsing entirely, so ordinary values containing `=`, `;`, spaces, or other special characters behave as expected.
+
+**Interaction with other labels:**
+
+- A TXT record is generated for every DNS name the container would normally receive an A/AAAA record for (container name, network aliases, Docker DNS names, Docker Compose `project.service`, and names from the `hostname` label).
+- If the `wildcard` label is also set, wildcard TXT records (`*.name.zone.` and `KEY.*.name.zone.`) are generated alongside the exact-match records.
+- If the `cname` label is set, TXT labels are **ignored** for that container. RFC 1034 §3.6.2 forbids a CNAME name from having other record types, and the plugin treats CNAMEd containers as fully aliased. A TXT query against such a container returns the CNAME record (since a CNAME applies regardless of query type), not the suppressed TXT value.
+
+**Query example:**
+
+```bash
+dig @127.0.0.1 -p 1053 web.docker. TXT
+```
+
+**Use cases:**
+
+- **Local DKIM / SPF fixtures.** Developers testing mail flow can attach `v=spf1` or a DKIM public-key TXT to a mail container and resolve it through the Docker network without touching public DNS.
+- **DNS-01 ACME challenges.** Integration tests that exercise ACME clients can publish a `txt._acme-challenge=<token>` label so the client under test resolves the challenge locally.
+- **Service metadata / version hints.** Small sidecars can expose their build version, git SHA, feature flags, or a short machine-readable config blob via `dig TXT <svc>.docker.`, much like `version.bind`.
+- **Lightweight config discovery.** Publish endpoint URLs or capability strings under keyed TXTs (e.g. `txt.endpoint=grpc://svc:50051`) that clients read once at startup instead of depending on a dedicated config service.
+
 ### Wildcard Records
 
 To enable wildcard DNS resolution for a container, add a label in the format:

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ This creates TXT records:
 
 - Multiple TXT labels on the same container accumulate: each contributes one TXT RR.
 - The keyed segment is lowercased when building the FQDN; `txt.Info=...` and `txt.info=...` produce the same record.
-- An empty label value is valid (e.g. `txt.empty=` yields `"" ` — RFC 1035 permits empty character-strings).
+- An empty label value is valid (e.g. `txt.empty=` yields an empty character-string — RFC 1035 permits empty TXT values).
 - TXT values longer than 255 bytes are automatically split into multiple 255-byte `character-string`s on the wire by the DNS library; no manual chunking is required.
 - A bare `txt.` label (trailing dot, no key) is ignored.
 

--- a/docker.go
+++ b/docker.go
@@ -50,8 +50,9 @@ type Docker struct {
 	mu           sync.RWMutex
 	records      map[string][]net.IP
 	srvs         map[string][]srvRecord
-	ptrs         map[string][]string // reverse-arpa FQDN -> container FQDNs
-	cnames       map[string]string   // FQDN -> canonical target (trailing dot)
+	ptrs         map[string][]string   // reverse-arpa FQDN -> container FQDNs
+	cnames       map[string]string     // FQDN -> canonical target (trailing dot)
+	txts         map[string][][]string // FQDN -> list of TXT RRs; each inner slice is one RR's character-strings
 	connected    bool
 	lastSyncTime time.Time
 }
@@ -165,7 +166,8 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	ips, ok := d.records[qname]
 	srvs, srvOk := d.srvs[qname]
 	cnameTarget, cnameOk := d.cnames[qname]
-	if !ok && !srvOk && !cnameOk {
+	txts, txtOk := d.txts[qname]
+	if !ok && !srvOk && !cnameOk && !txtOk {
 		// Try wildcard: replace the first non-underscore label with *
 		// This handles both plain names (foo.web.docker. → *.web.docker.)
 		// and SRV-prefixed names (_http._tcp.foo.web.docker. → _http._tcp.*.web.docker.)
@@ -182,16 +184,17 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			ips, ok = d.records[wildcardName]
 			srvs, srvOk = d.srvs[wildcardName]
 			cnameTarget, cnameOk = d.cnames[wildcardName]
-			if ok || srvOk || cnameOk {
+			txts, txtOk = d.txts[wildcardName]
+			if ok || srvOk || cnameOk || txtOk {
 				log.Debugf("Wildcard match for %s via %s", qname, wildcardName)
 			}
 		}
 	}
 	isConnected := d.connected
 	d.mu.RUnlock()
-	log.Debugf("Lookup results for %s: A/AAAA records=%d, SRV records=%d, CNAME=%t, connected=%t", qname, len(ips), len(srvs), cnameOk, isConnected)
+	log.Debugf("Lookup results for %s: A/AAAA records=%d, SRV records=%d, CNAME=%t, TXT records=%d, connected=%t", qname, len(ips), len(srvs), cnameOk, len(txts), isConnected)
 
-	if !ok && !srvOk && !cnameOk {
+	if !ok && !srvOk && !cnameOk && !txtOk {
 		if d.Fall.Through(qname) {
 			log.Debugf("No records found for %s, falling through to next plugin", qname)
 			requestFallthroughCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
@@ -259,6 +262,14 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			})
 			found = true
 		}
+	} else if qtype == dns.TypeTXT {
+		for _, strs := range txts {
+			m.Answer = append(m.Answer, &dns.TXT{
+				Hdr: header,
+				Txt: strs,
+			})
+			found = true
+		}
 	} else {
 		for _, ip := range ips {
 			if qtype == dns.TypeA && ip.To4() != nil {
@@ -278,7 +289,7 @@ func (d *Docker) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	}
 	log.Debugf("Response for %s %s: %d answer(s)", qname, dns.TypeToString[qtype], len(m.Answer))
 
-	if !found && (qtype == dns.TypeA || qtype == dns.TypeAAAA || qtype == dns.TypeSRV) {
+	if !found && (qtype == dns.TypeA || qtype == dns.TypeAAAA || qtype == dns.TypeSRV || qtype == dns.TypeTXT) {
 		// NODATA
 		log.Debugf("NODATA response for %s type %s: name exists but no matching records", qname, dns.TypeToString[qtype])
 		m.Ns = []dns.RR{d.soa(zone)}
@@ -416,7 +427,7 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	}
 	log.Debugf("Found %d running containers", len(containers))
 
-	newRecords, newSrvs, newPtrs, newCnames := generateRecords(ctx, GenerateRecordsInput{
+	newRecords, newSrvs, newPtrs, newCnames, newTxts := generateRecords(ctx, GenerateRecordsInput{
 		Containers:  containers,
 		Zones:       d.zones,
 		Inspector:   d.client,
@@ -431,6 +442,7 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	d.srvs = newSrvs
 	d.ptrs = newPtrs
 	d.cnames = newCnames
+	d.txts = newTxts
 	d.lastSyncTime = time.Now()
 	d.mu.Unlock()
 	lastSyncTimestamp.Set(float64(time.Now().Unix()))
@@ -439,8 +451,9 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	srvRecordsCount.Set(float64(len(newSrvs)))
 	ptrRecordsCount.Set(float64(len(newPtrs)))
 	cnameRecordsCount.Set(float64(len(newCnames)))
+	txtRecordsCount.Set(float64(len(newTxts)))
 	containersCount.Set(float64(len(containers)))
-	log.Debugf("Synced %d records, %d SRV records, %d PTR records, and %d CNAME records", len(newRecords), len(newSrvs), len(newPtrs), len(newCnames))
+	log.Debugf("Synced %d records, %d SRV records, %d PTR records, %d CNAME records, and %d TXT records", len(newRecords), len(newSrvs), len(newPtrs), len(newCnames), len(newTxts))
 }
 
 // ContainerInspector is an interface for inspecting containers.
@@ -470,12 +483,91 @@ type GenerateRecordsInput struct {
 	HostModePTR bool
 }
 
+// unescapeTxtCharString processes RFC 1035 §5.1 character-string
+// backslash escapes that the miekg/dns master-file parser preserves
+// verbatim in its output. This is applied after dns.NewRR so that the
+// character-strings stored (and later sent on the wire) match what users
+// writing values like `"say \"hi\""` or `"a\032b"` expect.
+//
+// Supported escapes:
+//
+//	\DDD – three-digit decimal byte (0–255)
+//	\X   – literal X for any other single character (covers \\ and \")
+//
+// A trailing lone backslash or a malformed decimal escape is kept
+// verbatim to avoid silently dropping bytes.
+func unescapeTxtCharString(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '\\' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		if i+1 >= len(s) {
+			b.WriteByte('\\')
+			i++
+			continue
+		}
+		next := s[i+1]
+		if next >= '0' && next <= '9' {
+			if i+3 < len(s) && s[i+2] >= '0' && s[i+2] <= '9' && s[i+3] >= '0' && s[i+3] <= '9' {
+				val := int(next-'0')*100 + int(s[i+2]-'0')*10 + int(s[i+3]-'0')
+				if val <= 255 {
+					b.WriteByte(byte(val))
+					i += 4
+					continue
+				}
+			}
+			b.WriteByte('\\')
+			i++
+			continue
+		}
+		b.WriteByte(next)
+		i += 2
+	}
+	return b.String()
+}
+
+// parseTxtValue converts a Docker label value into the Txt slice of a
+// dns.TXT RR. If the value starts with a double quote, it is parsed as
+// RFC 1035 master-file TXT rdata via miekg/dns and each resulting
+// character-string is then unescaped per RFC 1035 §5.1 (the miekg
+// parser preserves backslash escapes verbatim, so we post-process).
+// This supports multi-string TXT RRs like `"part1" "part2"` and
+// embedded quotes/backslashes via `\"` and `\\`. On parse failure the
+// raw label value is returned as a single character-string and a debug
+// message is logged. Values that do not start with a double quote are
+// always used verbatim as a single character-string, so ordinary label
+// values containing `=`, `;`, or spaces behave as expected.
+func parseTxtValue(v string) []string {
+	if len(v) > 0 && v[0] == '"' {
+		rr, err := dns.NewRR("dummy. 0 IN TXT " + v)
+		if err == nil {
+			if txt, ok := rr.(*dns.TXT); ok {
+				out := make([]string, len(txt.Txt))
+				for i, s := range txt.Txt {
+					out[i] = unescapeTxtCharString(s)
+				}
+				return out
+			}
+		}
+		log.Debugf("TXT label value %q looked like master-file format but did not parse; using verbatim", v)
+	}
+	return []string{v}
+}
+
 // generateRecords generates the records for the containers.
-func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[string][]net.IP, map[string][]srvRecord, map[string][]string, map[string]string) {
+func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[string][]net.IP, map[string][]srvRecord, map[string][]string, map[string]string, map[string][][]string) {
 	newRecords := make(map[string][]net.IP)
 	newSrvs := make(map[string][]srvRecord)
 	newPtrs := make(map[string][]string)
 	newCnames := make(map[string]string)
+	newTxts := make(map[string][][]string)
 
 	for _, c := range input.Containers {
 		inspect, err := input.Inspector.ContainerInspect(ctx, c.ID)
@@ -588,6 +680,34 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 				}
 				containerCname = lower
 			}
+		}
+
+		// Parse TXT labels. Two forms are supported:
+		//   <prefix>/txt=<value>        -> TXT at the container's own FQDN
+		//   <prefix>/txt.<key>=<value>  -> TXT at <key>.<container>.<zone>
+		// Values starting with `"` are parsed as RFC 1035 master-file TXT
+		// rdata (multiple character-strings, backslash escapes); all other
+		// values are stored verbatim as a single character-string. See
+		// parseTxtValue for details.
+		txtPrefix := input.LabelPrefix + "/txt"
+		if input.LabelPrefix == "" {
+			txtPrefix = "txt"
+		}
+		containerTxts := make(map[string][][]string)
+		for k, v := range inspect.Config.Labels {
+			if k == txtPrefix {
+				containerTxts[""] = append(containerTxts[""], parseTxtValue(v))
+				continue
+			}
+			if !strings.HasPrefix(k, txtPrefix+".") {
+				continue
+			}
+			suffix := strings.TrimPrefix(k, txtPrefix+".")
+			if suffix == "" {
+				continue
+			}
+			key := strings.ToLower(suffix)
+			containerTxts[key] = append(containerTxts[key], parseTxtValue(v))
 		}
 
 		// Add SRV records based on labels
@@ -843,6 +963,25 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 							}
 						}
 					}
+
+					for txtKey, rrs := range containerTxts {
+						var txtFqdn string
+						if txtKey == "" {
+							txtFqdn = fqdn
+						} else {
+							txtFqdn = txtKey + "." + fqdn
+						}
+						newTxts[txtFqdn] = append(newTxts[txtFqdn], rrs...)
+						if enableWildcard {
+							var wildcardTxtFqdn string
+							if txtKey == "" {
+								wildcardTxtFqdn = "*." + fqdn
+							} else {
+								wildcardTxtFqdn = txtKey + ".*." + fqdn
+							}
+							newTxts[wildcardTxtFqdn] = append(newTxts[wildcardTxtFqdn], rrs...)
+						}
+					}
 				}
 			}
 
@@ -898,6 +1037,15 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 				}
 			}
 		}
+
+		// Track which FQDNs we have already emitted TXT records for within
+		// this container, so that a multi-network container does not
+		// emit the same TXT RRs twice for a name that appears on every
+		// network (e.g. the container's base name). TXT records have no
+		// natural dedup key (unlike A/SRV which dedup by IP/port), so we
+		// rely on a per-container set here. Different containers claiming
+		// the same FQDN still accumulate independently.
+		txtEmitted := make(map[string]bool)
 
 		// Generate records for each matching network
 		for _, ne := range networksToProcess {
@@ -985,10 +1133,35 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 							}
 						}
 					}
+
+					for txtKey, rrs := range containerTxts {
+						var txtFqdn string
+						if txtKey == "" {
+							txtFqdn = fqdn
+						} else {
+							txtFqdn = txtKey + "." + fqdn
+						}
+						if !txtEmitted[txtFqdn] {
+							newTxts[txtFqdn] = append(newTxts[txtFqdn], rrs...)
+							txtEmitted[txtFqdn] = true
+						}
+						if enableWildcard {
+							var wildcardTxtFqdn string
+							if txtKey == "" {
+								wildcardTxtFqdn = "*." + fqdn
+							} else {
+								wildcardTxtFqdn = txtKey + ".*." + fqdn
+							}
+							if !txtEmitted[wildcardTxtFqdn] {
+								newTxts[wildcardTxtFqdn] = append(newTxts[wildcardTxtFqdn], rrs...)
+								txtEmitted[wildcardTxtFqdn] = true
+							}
+						}
+					}
 				}
 			}
 		}
 	}
 
-	return newRecords, newSrvs, newPtrs, newCnames
+	return newRecords, newSrvs, newPtrs, newCnames, newTxts
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -54,6 +54,19 @@ func TestDocker(t *testing.T) {
 			"5.0.17.172.in-addr.arpa.":                                                      {"multi.docker."},
 			"6.0.17.172.in-addr.arpa.":                                                      {"myproj.mysvc.docker."},
 		},
+		txts: map[string][][]string{
+			// TXT on a name that also has an A record (web.docker.)
+			"web.docker.": {{"v=spf1 -all"}},
+			// Keyed TXT at a TXT-only FQDN — no A record here. Proves that
+			// txtOk participates in the ServeDNS "does this name exist"
+			// check so the query does not fall through to NXDOMAIN.
+			"info.web.docker.": {{"version=1.0.0"}},
+			// Multiple TXT RRs on the same FQDN — response contains N answers.
+			"multi-txt.docker.": {{"one"}, {"two"}},
+			// One TXT RR containing two character-strings — response contains
+			// a single answer whose Txt slice has length 2.
+			"multi-str.docker.": {{"part1", "part2"}},
+		},
 	}
 
 	var cases = []test.Case{
@@ -120,6 +133,81 @@ func TestDocker(t *testing.T) {
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
 				test.SRV("_udp._udp.db.docker.	30	IN	SRV	10 10 5432 db.docker."),
+			},
+		},
+		{
+			// TXT query on a name that has both A and TXT records
+			Qname: "web.docker.",
+			Qtype: dns.TypeTXT,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.TXT("web.docker.	30	IN	TXT	\"v=spf1 -all\""),
+			},
+		},
+		{
+			// TXT query on a TXT-only FQDN (no A record). This specifically
+			// verifies that txtOk participates in the ServeDNS existence
+			// check — without it, the name would look nonexistent.
+			Qname: "info.web.docker.",
+			Qtype: dns.TypeTXT,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.TXT("info.web.docker.	30	IN	TXT	\"version=1.0.0\""),
+			},
+		},
+		{
+			// NODATA: A query on a TXT-only FQDN. Name exists (via TXT)
+			// but has no A record, so the response is empty with SOA in
+			// the authority section. Proves the new NODATA condition
+			// correctly handles "name exists only for TXT".
+			Qname:  "info.web.docker.",
+			Qtype:  dns.TypeA,
+			Rcode:  dns.RcodeSuccess,
+			Answer: []dns.RR{},
+			Ns: []dns.RR{
+				test.SOA("docker. 30 IN SOA ns.dns.docker. hostmaster.docker. 0 7200 1800 86400 30"),
+			},
+		},
+		{
+			// Multiple TXT RRs on the same FQDN → multiple answers.
+			Qname: "multi-txt.docker.",
+			Qtype: dns.TypeTXT,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.TXT("multi-txt.docker.	30	IN	TXT	\"one\""),
+				test.TXT("multi-txt.docker.	30	IN	TXT	\"two\""),
+			},
+		},
+		{
+			// One TXT RR with two character-strings → one answer whose
+			// text-rendered form contains both strings.
+			Qname: "multi-str.docker.",
+			Qtype: dns.TypeTXT,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.TXT("multi-str.docker.	30	IN	TXT	\"part1\" \"part2\""),
+			},
+		},
+		{
+			// NODATA: TXT query on a name that has only A records.
+			// Proves TXT is included in the NODATA condition so queries
+			// for unsupported types return NOERROR with SOA, not NXDOMAIN.
+			Qname:  "db.docker.",
+			Qtype:  dns.TypeTXT,
+			Rcode:  dns.RcodeSuccess,
+			Answer: []dns.RR{},
+			Ns: []dns.RR{
+				test.SOA("docker. 30 IN SOA ns.dns.docker. hostmaster.docker. 0 7200 1800 86400 30"),
+			},
+		},
+		{
+			// NXDOMAIN for a TXT query on an entirely unknown name.
+			Qname:  "nope.docker.",
+			Qtype:  dns.TypeTXT,
+			Rcode:  dns.RcodeNameError,
+			Answer: []dns.RR{},
+			Ns: []dns.RR{
+				test.SOA("docker. 30 IN SOA ns.dns.docker. hostmaster.docker. 0 7200 1800 86400 30"),
 			},
 		},
 		{

--- a/e2e.bats
+++ b/e2e.bats
@@ -453,6 +453,157 @@ assert_output_contains() {
   docker rm -f coredns-e2e-cname-noa
 }
 
+@test "[e2e] txt label: simple TXT label resolves at container FQDN" {
+  docker run -d --name coredns-e2e-txt --network bridge \
+    --label "com.dokku.coredns-docker/txt=v=spf1 -all" \
+    alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-txt.${COREDNS_ZONE}" "TXT"
+  assert_success
+  assert_output_contains "v=spf1 -all"
+
+  docker rm -f coredns-e2e-txt
+}
+
+@test "[e2e] txt label: keyed TXT label resolves at keyed FQDN" {
+  docker run -d --name coredns-e2e-txt-keyed --network bridge \
+    --label "com.dokku.coredns-docker/txt._acme-challenge=tok123" \
+    alpine sleep 3600
+
+  run wait_for_record "_acme-challenge.coredns-e2e-txt-keyed.${COREDNS_ZONE}" "TXT"
+  assert_success
+  assert_output_contains "tok123"
+
+  docker rm -f coredns-e2e-txt-keyed
+}
+
+@test "[e2e] txt label: TXT coexists with A record" {
+  docker run -d --name coredns-e2e-txt-a --network bridge \
+    --label "com.dokku.coredns-docker/txt=metadata=1" \
+    alpine sleep 3600
+
+  # The container still gets a normal A record.
+  run wait_for_record "coredns-e2e-txt-a.${COREDNS_ZONE}" "A"
+  assert_success
+  [[ "$output" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]
+
+  # And the TXT label resolves at the same name.
+  run wait_for_record "coredns-e2e-txt-a.${COREDNS_ZONE}" "TXT"
+  assert_success
+  assert_output_contains "metadata=1"
+
+  docker rm -f coredns-e2e-txt-a
+}
+
+@test "[e2e] txt label: TXT NODATA for A-only container" {
+  docker run -d --name coredns-e2e-txt-nodata --network bridge alpine sleep 3600
+
+  # Wait for the A record so we know the container is registered.
+  run wait_for_record "coredns-e2e-txt-nodata.${COREDNS_ZONE}" "A"
+  assert_success
+
+  # A TXT query should return NOERROR with zero answers.
+  run dig +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-txt-nodata.${COREDNS_ZONE}" TXT
+  assert_success
+  assert_output_contains "status: NOERROR"
+  assert_output_contains "ANSWER: 0"
+
+  docker rm -f coredns-e2e-txt-nodata
+}
+
+@test "[e2e] txt label: quoted-form multi-string produces one RR with two strings" {
+  docker run -d --name coredns-e2e-txt-multi --network bridge \
+    --label 'com.dokku.coredns-docker/txt="part1" "part2"' \
+    alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-txt-multi.${COREDNS_ZONE}" "TXT"
+  assert_success
+  # dig +short renders a multi-string TXT RR as `"part1" "part2"`.
+  assert_output_contains "part1"
+  assert_output_contains "part2"
+
+  # Confirm it really is a single RR (ANSWER: 1) and not two RRs.
+  run dig +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-txt-multi.${COREDNS_ZONE}" TXT
+  assert_success
+  assert_output_contains "ANSWER: 1"
+
+  docker rm -f coredns-e2e-txt-multi
+}
+
+@test "[e2e] txt label: quoted-form with escaped quote unescapes to literal quote" {
+  docker run -d --name coredns-e2e-txt-esc --network bridge \
+    --label 'com.dokku.coredns-docker/txt="say \"hi\""' \
+    alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-txt-esc.${COREDNS_ZONE}" "TXT"
+  assert_success
+  # dig +short re-quotes the TXT character-string and re-escapes embedded
+  # double-quotes, so the raw characters say "hi" appear as say \"hi\" in
+  # the output. The important thing is that `say` and the `hi` are present
+  # and there is no second backslash-escape layer from our own parser.
+  assert_output_contains "say"
+  assert_output_contains "hi"
+
+  docker rm -f coredns-e2e-txt-esc
+}
+
+@test "[e2e] txt label: quoted-form with escaped backslash unescapes to single backslash" {
+  docker run -d --name coredns-e2e-txt-bs --network bridge \
+    --label 'com.dokku.coredns-docker/txt="path\\to\\file"' \
+    alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-txt-bs.${COREDNS_ZONE}" "TXT"
+  assert_success
+  # The stored character-string is `path\to\file` (single backslashes).
+  # dig +short re-escapes each backslash, so the visible output contains
+  # `path\\to\\file`. Assert on the substring-level components.
+  assert_output_contains "path"
+  assert_output_contains "to"
+  assert_output_contains "file"
+
+  docker rm -f coredns-e2e-txt-bs
+}
+
+@test "[e2e] txt label: malformed quoted-form falls back to verbatim" {
+  # Leading quote with no terminator — miekg's master-file parser rejects
+  # this and the plugin falls back to storing the raw value.
+  docker run -d --name coredns-e2e-txt-bad --network bridge \
+    --label 'com.dokku.coredns-docker/txt="unterminated' \
+    alpine sleep 3600
+
+  run wait_for_record "coredns-e2e-txt-bad.${COREDNS_ZONE}" "TXT"
+  assert_success
+  # The stored value is the literal 13-byte string `"unterminated`
+  # (leading quote preserved). dig +short wraps the character-string in
+  # quotes and escapes the leading quote as \".
+  assert_output_contains "unterminated"
+
+  docker rm -f coredns-e2e-txt-bad
+}
+
+@test "[e2e] txt label: TXT is suppressed for cname containers" {
+  docker run -d --name coredns-e2e-txt-cname --network bridge \
+    --label "com.dokku.coredns-docker/cname=external.example.com" \
+    --label "com.dokku.coredns-docker/txt=metadata=should-not-appear" \
+    alpine sleep 3600
+
+  # Wait for the CNAME so we know the container is registered.
+  run wait_for_record "coredns-e2e-txt-cname.${COREDNS_ZONE}" "CNAME"
+  assert_success
+
+  # A TXT query against a CNAME name returns the CNAME answer (per
+  # RFC 1034 §3.6.2 — CNAME applies regardless of query type). The
+  # answer section must contain the CNAME target and must NOT contain
+  # the suppressed TXT metadata.
+  run dig +time=2 +tries=1 @127.0.0.1 -p "$COREDNS_PORT" "coredns-e2e-txt-cname.${COREDNS_ZONE}" TXT
+  assert_success
+  assert_output_contains "status: NOERROR"
+  assert_output_contains "external.example.com."
+  [[ ! "$output" =~ should-not-appear ]]
+
+  docker rm -f coredns-e2e-txt-cname
+}
+
 @test "[e2e] network filtering: container on unmonitored network does not resolve" {
   docker network create coredns-e2e-unmonitored 2>/dev/null || true
   docker run -d --name coredns-e2e-filtered --network coredns-e2e-unmonitored alpine sleep 3600

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -33,6 +34,7 @@ type generateRecordsExpected struct {
 	srvs    map[string][]srvRecord
 	ptrs    map[string][]string
 	cnames  map[string]string
+	txts    map[string][][]string
 }
 
 func TestGenerateRecords(t *testing.T) {
@@ -2875,11 +2877,645 @@ func TestGenerateRecords(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "container with simple TXT label",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt": "v=spf1 -all",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"web.docker.": {{"v=spf1 -all"}},
+				},
+			},
+		},
+		{
+			name: "container with keyed TXT label",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt._acme-challenge": "tok123",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"_acme-challenge.web.docker.": {{"tok123"}},
+				},
+			},
+		},
+		{
+			name: "container with multiple TXT labels",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt":         "v=spf1 -all",
+									"com.dokku.coredns-docker/txt.info":    "version=1.0.0",
+									"com.dokku.coredns-docker/txt.contact": "admin@example.com",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"web.docker.":         {{"v=spf1 -all"}},
+					"info.web.docker.":    {{"version=1.0.0"}},
+					"contact.web.docker.": {{"admin@example.com"}},
+				},
+			},
+		},
+		{
+			name: "container with TXT label and empty label prefix",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"txt":      "hello",
+									"txt.info": "world",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"web.docker.":      {{"hello"}},
+					"info.web.docker.": {{"world"}},
+				},
+			},
+		},
+		{
+			name: "container with TXT label and network aliases",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt": "metadata",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+										Aliases:   []string{"www"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+					"www.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker.", "www.docker."}},
+				txts: map[string][][]string{
+					"web.docker.": {{"metadata"}},
+					"www.docker.": {{"metadata"}},
+				},
+			},
+		},
+		{
+			name: "container with TXT label and wildcard",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt":      "metadata",
+									"com.dokku.coredns-docker/wildcard": "true",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.":   {net.ParseIP("172.17.0.2")},
+					"*.web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"web.docker.":   {{"metadata"}},
+					"*.web.docker.": {{"metadata"}},
+				},
+			},
+		},
+		{
+			name: "container with TXT label suppressed under cname",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/cname": "external.example.com.",
+									"com.dokku.coredns-docker/txt":   "metadata",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				// CNAME fully suppresses all other record types for the container,
+				// including TXT, per RFC 1034 §3.6.2.
+				records: map[string][]net.IP{},
+				srvs:    map[string][]srvRecord{},
+				ptrs:    map[string][]string{},
+				cnames: map[string]string{
+					"web.docker.": "external.example.com.",
+				},
+			},
+		},
+		{
+			name: "container with empty TXT label value",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt.empty": "",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"empty.web.docker.": {{""}},
+				},
+			},
+		},
+		{
+			name: "container with bare txt. label is ignored",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt.": "ignored",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
+		{
+			name: "container with quoted-form TXT label, single string",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt": `"hello world"`,
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					// Quotes get stripped by the master-file parser, leaving one
+					// character-string with the quoted contents.
+					"web.docker.": {{"hello world"}},
+				},
+			},
+		},
+		{
+			name: "container with quoted-form TXT label, multi-string",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt": `"part1" "part2"`,
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					// One TXT RR with two character-strings.
+					"web.docker.": {{"part1", "part2"}},
+				},
+			},
+		},
+		{
+			name: "container with quoted-form TXT label, escaped quote",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									`com.dokku.coredns-docker/txt`: `"say \"hi\""`,
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					// Backslash-escaped quotes become literal quotes in the
+					// stored character-string.
+					"web.docker.": {{`say "hi"`}},
+				},
+			},
+		},
+		{
+			name: "container with quoted-form TXT label, decimal escape",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									// \065 decimal == 'A' (0x41)
+									"com.dokku.coredns-docker/txt": `"hello\065world"`,
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					"web.docker.": {{"helloAworld"}},
+				},
+			},
+		},
+		{
+			name: "container with malformed quoted-form TXT label falls back to verbatim",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/txt": `"unterminated`,
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress: "172.17.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+				txts: map[string][][]string{
+					// Parse failed → raw label value stored verbatim as a single
+					// character-string, leading quote preserved.
+					"web.docker.": {{`"unterminated`}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			records, srvs, ptrs, cnames := generateRecords(ctx, tt.input)
+			records, srvs, ptrs, cnames, txts := generateRecords(ctx, tt.input)
 
 			// Check records
 			if len(records) != len(tt.expected.records) {
@@ -2996,6 +3632,37 @@ func TestGenerateRecords(t *testing.T) {
 				}
 				if actualTarget != expectedTarget {
 					t.Errorf("expected CNAME target %s for %s, got %s", expectedTarget, fqdn, actualTarget)
+				}
+			}
+
+			// Check TXT records
+			if len(txts) != len(tt.expected.txts) {
+				t.Errorf("expected %d TXT record names, got %d", len(tt.expected.txts), len(txts))
+				for fqdn := range txts {
+					if _, ok := tt.expected.txts[fqdn]; !ok {
+						t.Errorf("unexpected TXT record: %s", fqdn)
+					}
+				}
+				for fqdn := range tt.expected.txts {
+					if _, ok := txts[fqdn]; !ok {
+						t.Errorf("missing TXT record: %s", fqdn)
+					}
+				}
+			}
+			for fqdn, expectedRRs := range tt.expected.txts {
+				actualRRs, ok := txts[fqdn]
+				if !ok {
+					t.Errorf("expected TXT record for %s, not found", fqdn)
+					continue
+				}
+				if len(actualRRs) != len(expectedRRs) {
+					t.Errorf("expected %d TXT RRs for %s, got %d", len(expectedRRs), fqdn, len(actualRRs))
+					continue
+				}
+				for i, expectedRR := range expectedRRs {
+					if !reflect.DeepEqual(actualRRs[i], expectedRR) {
+						t.Errorf("expected TXT RR %+v for %s at index %d, got %+v", expectedRR, fqdn, i, actualRRs[i])
+					}
 				}
 			}
 		})

--- a/integration_test.go
+++ b/integration_test.go
@@ -93,6 +93,7 @@ func setupIntegrationDocker(t *testing.T, networks []string) (*Docker, *client.C
 		srvs:        make(map[string][]srvRecord),
 		ptrs:        make(map[string][]string),
 		cnames:      make(map[string]string),
+		txts:        make(map[string][][]string),
 	}
 
 	return d, cli
@@ -1183,3 +1184,188 @@ func TestIntegrationPTRAfterRemoval(t *testing.T) {
 		t.Errorf("expected SERVFAIL for PTR %s after removal, got rcode %d", arpa, rcode)
 	}
 }
+
+// assertTxtAnswer fatals if the DNS response does not contain a single
+// TXT answer whose Txt slice exactly matches want. Common helper for the
+// TXT integration tests below.
+func assertTxtAnswer(t *testing.T, d *Docker, qname string, want []string) {
+	t.Helper()
+	resp, _, err := queryDNS(t, d, qname, dns.TypeTXT)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s TXT: %v", qname, err)
+	}
+	if resp == nil {
+		t.Fatalf("expected DNS response for %s TXT, got nil", qname)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected exactly one TXT answer for %s, got %d", qname, len(resp.Answer))
+	}
+	txt, ok := resp.Answer[0].(*dns.TXT)
+	if !ok {
+		t.Fatalf("expected TXT record for %s, got %T", qname, resp.Answer[0])
+	}
+	if len(txt.Txt) != len(want) {
+		t.Fatalf("expected %d character-strings for %s, got %d: %#v", len(want), qname, len(txt.Txt), txt.Txt)
+	}
+	for i, w := range want {
+		if txt.Txt[i] != w {
+			t.Errorf("expected Txt[%d]=%q for %s, got %q", i, w, qname, txt.Txt[i])
+		}
+	}
+}
+
+func TestIntegrationTXTRecord(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			"com.dokku.coredns-docker/txt": "version=1.0.0",
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{"version=1.0.0"})
+}
+
+func TestIntegrationTXTKeyedRecord(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			"com.dokku.coredns-docker/txt._acme-challenge": "tok123",
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, "_acme-challenge."+name+".docker.", []string{"tok123"})
+}
+
+func TestIntegrationTXTQuotedMultiString(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			// Quoted-form value producing one TXT RR with two character-strings.
+			"com.dokku.coredns-docker/txt": `"part1" "part2"`,
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{"part1", "part2"})
+}
+
+func TestIntegrationTXTQuotedEscapedQuote(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			// `\"` must be post-processed to a literal `"` in the stored
+			// character-string.
+			"com.dokku.coredns-docker/txt": `"say \"hi\""`,
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{`say "hi"`})
+}
+
+func TestIntegrationTXTQuotedEscapedBackslash(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			// `\\` must collapse to a single literal backslash.
+			"com.dokku.coredns-docker/txt": `"path\\to\\file"`,
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{`path\to\file`})
+}
+
+func TestIntegrationTXTQuotedDecimalEscape(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			// `\065` decimal → 'A'.
+			"com.dokku.coredns-docker/txt": `"hello\065world"`,
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{"helloAworld"})
+}
+
+func TestIntegrationTXTQuotedMalformedFallback(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			// Leading `"` triggers quoted-form parsing, but no closing quote
+			// exists. miekg returns an error and the parser falls back to
+			// storing the raw label value verbatim (including the leading
+			// quote) as a single character-string.
+			"com.dokku.coredns-docker/txt": `"unterminated`,
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{`"unterminated`})
+}
+
+func TestIntegrationTXTUnquotedVerbatim(t *testing.T) {
+	d, cli := setupIntegrationDocker(t, nil)
+	ctx := context.Background()
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+		Labels: map[string]string{
+			// Non-quoted values bypass master-file parsing entirely, so
+			// characters like `=` and `;` pass through untouched.
+			"com.dokku.coredns-docker/txt": "key=val;other=val2",
+		},
+	}, nil, nil)
+
+	d.syncRecords(ctx)
+
+	assertTxtAnswer(t, d, name+".docker.", []string{"key=val;other=val2"})
+}
+

--- a/metrics.go
+++ b/metrics.go
@@ -79,6 +79,13 @@ var (
 		Name:      "cname_records_total",
 		Help:      "Number of CNAME DNS record names currently tracked.",
 	})
+	// txtRecordsCount is the number of TXT DNS record names currently tracked.
+	txtRecordsCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "txt_records_total",
+		Help:      "Number of TXT DNS record names currently tracked.",
+	})
 	// connectedGauge indicates whether the plugin is connected to the Docker daemon.
 	connectedGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,

--- a/setup.go
+++ b/setup.go
@@ -25,6 +25,7 @@ func setup(c *caddy.Controller) error {
 		srvs:        make(map[string][]srvRecord),
 		ptrs:        make(map[string][]string),
 		cnames:      make(map[string]string),
+		txts:        make(map[string][][]string),
 		ttl:         DefaultTTL,
 		zones:       []string{"docker."},
 	}


### PR DESCRIPTION
## Summary

Closes #52.

Adds TXT record support driven by Docker labels, mirroring the existing
SRV and CNAME label patterns. Two label forms are supported:

- `<prefix>/txt=<value>` attaches a TXT record at the container's own FQDN.
- `<prefix>/txt.<key>=<value>` attaches a TXT record at `<key>.<container>.<zone>`.

TXT records propagate across all of a container's DNS names (container
name, network aliases, Docker DNS names, Docker Compose
`project.service`, hostname label). They respect the `wildcard` label
and are suppressed for CNAMEd containers per RFC 1034 §3.6.2.

## Quoted-form values and escape sequences

A label value that starts with `"` is parsed as RFC 1035 master-file
TXT rdata via `miekg/dns`, letting a single label produce a multi-string
TXT RR (`"part1" "part2"`) and supporting backslash escapes (`\"`,
`\\`, `\DDD`). Because the miekg parser preserves backslash sequences
verbatim, the plugin post-processes each resulting character-string to
honor the RFC 1035 §5.1 escape rules. Malformed quoted values
(unterminated quote, bad decimal) fall back to storing the raw label
value verbatim as a single character-string.

Values that do not start with `"` bypass master-file parsing entirely,
so ordinary values containing `=`, `;`, spaces, etc. behave as written.

## Use cases

Documented in `README.md`:

- Local DKIM / SPF fixtures for mail development.
- `_acme-challenge.*` TXT for testing ACME DNS-01 clients without
  touching public DNS.
- Service metadata (version, git SHA, feature flags) readable via
  `dig TXT <svc>.docker.`.
- Lightweight config discovery (endpoint URLs, capability strings).