### PR TITLE
ci: report test coverage in integration-test job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,4 +52,27 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: go get .
-      - run: make test-integration
+      - name: Run tests with coverage
+        run: make coverage
+      - name: Write coverage summary
+        if: always()
+        run: |
+          if [ ! -f coverage.out ]; then
+            echo "coverage.out not produced (test binary likely failed to compile)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          total=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
+          {
+            echo "## Test coverage: ${total}"
+            echo ""
+            echo '```'
+            go tool cover -func=coverage.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-profile
+          path: coverage.out
+          retention-days: 7


### PR DESCRIPTION
## Summary

- Replaces `make test-integration` with `make coverage` in the `integration-test` workflow job so the same test corpus now produces a coverage profile as a side effect.
- Writes a `## Test coverage: N.N%` heading plus the full `go tool cover -func` per-function table to `$GITHUB_STEP_SUMMARY`, visible in the Actions tab for each run. Guarded so a missing `coverage.out` (compile failure) degrades to a one-line note instead of failing the step.
- Uploads `coverage.out` as the `coverage-profile` artifact with 7-day retention so contributors can pull the raw profile and inspect it with `go tool cover -html`.

No external services, no README badge, no new jobs. The integration test corpus runs exactly once per CI run.