### PR TITLE
feat: install systemd service and Corefile via deb package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,9 @@ jobs:
           sha1sum "build/deb/${NAME}_${VERSION}_amd64.deb"
           sha1sum "build/deb/${NAME}_${VERSION}_arm64.deb"
           bats test.bats
+      - name: Test deb lifecycle
+        run: |
+          packaging/test-lifecycle.sh "build/deb/${NAME}_${VERSION}_amd64.deb"
       - name: upload packages
         uses: actions/upload-artifact@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 		&& fpm \
 		--architecture amd64 \
 		--category utils \
+		--depends adduser \
 		--depends net-tools \
 		--depends util-linux \
 		--description "$$PACKAGE_DESCRIPTION" \
@@ -118,7 +119,13 @@ build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 		--vendor "" \
 		--version $(VERSION) \
 		--verbose \
+		--config-files /etc/coredns/Corefile \
+		--after-install packaging/postinst \
+		--before-remove packaging/prerm \
+		--after-remove packaging/postrm \
 		build/linux/$(NAME)-amd64=/usr/bin/$(NAME) \
+		packaging/Corefile=/etc/coredns/Corefile \
+		packaging/coredns-docker.service=/lib/systemd/system/coredns-docker.service \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
@@ -127,6 +134,7 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		&& fpm \
 		--architecture arm64 \
 		--category utils \
+		--depends adduser \
 		--depends net-tools \
 		--depends util-linux \
 		--description "$$PACKAGE_DESCRIPTION" \
@@ -140,7 +148,13 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		--vendor "" \
 		--version $(VERSION) \
 		--verbose \
+		--config-files /etc/coredns/Corefile \
+		--after-install packaging/postinst \
+		--before-remove packaging/prerm \
+		--after-remove packaging/postrm \
 		build/linux/$(NAME)-arm64=/usr/bin/$(NAME) \
+		packaging/Corefile=/etc/coredns/Corefile \
+		packaging/coredns-docker.service=/lib/systemd/system/coredns-docker.service \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 .PHONY: build-local

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,9 +25,24 @@ curl -s https://packagecloud.io/install/repositories/dokku/dokku/script.deb.sh |
 sudo apt install coredns-docker
 ```
 
-This installs the binary as `/usr/bin/coredns-docker`. It does **not** install a Corefile or a systemd unit -- bring your own. See [linux-systemd.md](linux-systemd.md) for a sample unit file.
+The package installs:
+
+- `/usr/bin/coredns-docker` -- the binary.
+- `/etc/coredns/Corefile` -- a default Corefile that binds `:1053` and serves the `docker.localhost` zone. Marked as a Debian conffile, so your edits survive upgrades.
+- `/lib/systemd/system/coredns-docker.service` -- a hardened systemd unit ordered after `docker.service` and before `nginx.service` (so reverse-proxy upstreams that resolve via container DNS are reachable before nginx starts).
+
+A dedicated `coredns-docker` system user is created and added to the `docker` group so it can read `/var/run/docker.sock`. The unit is enabled and started automatically, so by the time `apt` returns the service is already serving DNS on port `1053`.
+
+```bash
+systemctl status coredns-docker
+dig @127.0.0.1 -p 1053 docker.localhost SOA
+```
+
+`apt remove coredns-docker` stops the service and removes the binary and unit, but keeps `/etc/coredns/Corefile` (standard Debian conffile behavior). `apt purge coredns-docker` additionally removes `/etc/coredns/`, the `coredns-docker` user, and the `coredns-docker` group, leaving the host as if the package had never been installed.
 
 **Why a `.deb` instead of a tarball?** `apt` handles upgrades, signature checking, and uninstallation cleanly. On Debian and Ubuntu hosts the deb is usually the least painful way to keep the plugin up to date.
+
+**Want port `53` or a different Corefile?** Edit `/etc/coredns/Corefile` and run `systemctl reload coredns-docker`. If you switch to port `53`, also drop in `AmbientCapabilities=CAP_NET_BIND_SERVICE` via `systemctl edit coredns-docker`. See [linux-systemd.md](linux-systemd.md) for the full unit reference.
 
 ## From source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,14 +28,14 @@ sudo apt install coredns-docker
 The package installs:
 
 - `/usr/bin/coredns-docker` -- the binary.
-- `/etc/coredns/Corefile` -- a default Corefile that binds `:1053` and serves the `docker.localhost` zone. Marked as a Debian conffile, so your edits survive upgrades.
+- `/etc/coredns/Corefile` -- a default Corefile that binds `:1053` and serves the `docker.` zone (so `web.docker`, `db.docker`, etc., resolve to the matching containers). Marked as a Debian conffile, so your edits survive upgrades.
 - `/lib/systemd/system/coredns-docker.service` -- a hardened systemd unit ordered after `docker.service` and before `nginx.service` (so reverse-proxy upstreams that resolve via container DNS are reachable before nginx starts).
 
 A dedicated `coredns-docker` system user is created and added to the `docker` group so it can read `/var/run/docker.sock`. The unit is enabled and started automatically, so by the time `apt` returns the service is already serving DNS on port `1053`.
 
 ```bash
 systemctl status coredns-docker
-dig @127.0.0.1 -p 1053 docker.localhost SOA
+dig @127.0.0.1 -p 1053 docker. SOA
 ```
 
 `apt remove coredns-docker` stops the service and removes the binary and unit, but keeps `/etc/coredns/Corefile` (standard Debian conffile behavior). `apt purge coredns-docker` additionally removes `/etc/coredns/`, the `coredns-docker` user, and the `coredns-docker` group, leaving the host as if the package had never been installed.

--- a/docs/linux-systemd.md
+++ b/docs/linux-systemd.md
@@ -51,9 +51,35 @@ Both should return the container's IP without specifying a resolver explicitly.
 
 ## 2. Run CoreDNS as a systemd service
 
-Deployed hosts usually want CoreDNS running as a managed service that starts on boot, restarts on failure, and logs to the journal. Here is a minimal unit file.
+Deployed hosts usually want CoreDNS running as a managed service that starts on boot, restarts on failure, and logs to the journal.
 
-Install the binary to `/usr/bin/coredns-docker` (via the `.deb` package or by copying a release binary into place) and your `Corefile` to `/etc/coredns/Corefile`. Create a dedicated system user:
+### If you installed via the Debian package
+
+`apt install coredns-docker` already installs and starts the service for you. The package ships:
+
+- `/lib/systemd/system/coredns-docker.service` -- the unit (same shape as the manual unit below, minus `CAP_NET_BIND_SERVICE` since it binds `:1053`).
+- `/etc/coredns/Corefile` -- a default Corefile, marked as a conffile so your edits survive upgrades.
+- A `coredns-docker` system user/group, with the user added to the `docker` group.
+
+Check status, follow logs, and reload after editing the Corefile:
+
+```bash
+sudo systemctl status coredns-docker
+journalctl -u coredns-docker -f
+sudo systemctl reload coredns-docker   # SIGUSR1, no dropped queries
+```
+
+To customize the unit (for example to add `AmbientCapabilities=CAP_NET_BIND_SERVICE` so you can bind `:53`), use a dropin so your changes are not overwritten on upgrade:
+
+```bash
+sudo systemctl edit coredns-docker
+```
+
+Skip ahead to [Section 1](#1-route-docker-queries-via-systemd-resolved) if you also want `docker.` lookups routed through the service system-wide.
+
+### If you installed from a release binary or built from source
+
+You need to wire the service up yourself. Install the binary to `/usr/bin/coredns-docker` and your `Corefile` to `/etc/coredns/Corefile`. Create a dedicated system user:
 
 ```bash
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin coredns
@@ -80,6 +106,7 @@ Create `/etc/systemd/system/coredns.service`:
 Description=CoreDNS with docker plugin
 Documentation=https://github.com/dokku/coredns-docker
 After=network-online.target docker.service
+Before=nginx.service
 Wants=network-online.target
 Requires=docker.service
 
@@ -106,6 +133,8 @@ WantedBy=multi-user.target
 **Why `CAP_NET_BIND_SERVICE`?** This capability lets an unprivileged process bind to ports below 1024. If your Corefile uses port `53` you need it; if you stick with port `1053` you can remove both the `AmbientCapabilities=` and `CapabilityBoundingSet=` lines.
 
 **Why `Requires=docker.service`?** The plugin fails to start if it cannot ping the Docker daemon, so ordering CoreDNS after `docker.service` avoids a spurious startup failure on boot. `Requires` (as opposed to `After`) ensures systemd starts Docker alongside CoreDNS if it is not already running.
+
+**Why `Before=nginx.service`?** If nginx is configured to upstream by container hostname (e.g., `proxy_pass http://web.docker:8080;`), nginx needs `127.0.0.1:1053` answering before it tries to resolve those upstreams during startup, or it will refuse to start. `Before=` is purely ordering: it pulls nothing in, so the line is a no-op on hosts that do not have nginx installed.
 
 Enable and start the service:
 

--- a/packaging/Corefile
+++ b/packaging/Corefile
@@ -1,0 +1,16 @@
+docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
+    ready {
+        monitor continuously
+    }
+    errors
+    health
+    log
+    docker {
+        ttl 10
+        label_prefix com.dokku.coredns-docker
+        max_backoff 30s
+        zone docker.localhost
+    }
+    prometheus :9153
+    cache 30
+}

--- a/packaging/Corefile
+++ b/packaging/Corefile
@@ -9,7 +9,6 @@ docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
         ttl 10
         label_prefix com.dokku.coredns-docker
         max_backoff 30s
-        zone docker.localhost
     }
     prometheus :9153
     cache 30

--- a/packaging/coredns-docker.service
+++ b/packaging/coredns-docker.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=CoreDNS with docker plugin
+Documentation=https://github.com/dokku/coredns-docker
+After=network-online.target docker.service
+Before=nginx.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=coredns-docker
+Group=coredns-docker
+ExecStart=/usr/bin/coredns-docker -conf /etc/coredns/Corefile
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+Restart=on-failure
+RestartSec=5s
+LimitNOFILE=1048576
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        if ! getent group coredns-docker >/dev/null; then
+            addgroup --system coredns-docker
+        fi
+
+        if ! getent passwd coredns-docker >/dev/null; then
+            adduser --system \
+                --no-create-home \
+                --ingroup coredns-docker \
+                --shell /usr/sbin/nologin \
+                coredns-docker
+        fi
+
+        if getent group docker >/dev/null; then
+            adduser coredns-docker docker >/dev/null || true
+        fi
+
+        if [ -d /etc/coredns ]; then
+            chown root:coredns-docker /etc/coredns
+            chmod 0750 /etc/coredns
+        fi
+
+        if [ -f /etc/coredns/Corefile ]; then
+            chown root:coredns-docker /etc/coredns/Corefile
+            chmod 0640 /etc/coredns/Corefile
+        fi
+        ;;
+esac
+
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+fi
+
+if [ -x /usr/bin/deb-systemd-helper ]; then
+    deb-systemd-helper unmask coredns-docker.service >/dev/null || true
+
+    if deb-systemd-helper --quiet was-enabled coredns-docker.service; then
+        deb-systemd-helper enable coredns-docker.service >/dev/null || true
+    else
+        deb-systemd-helper update-state coredns-docker.service >/dev/null || true
+    fi
+fi
+
+if [ -d /run/systemd/system ]; then
+    if [ -n "$2" ]; then
+        deb-systemd-invoke try-restart coredns-docker.service >/dev/null || true
+    else
+        deb-systemd-invoke start coredns-docker.service >/dev/null || true
+    fi
+fi
+
+exit 0

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -2,55 +2,55 @@
 set -e
 
 case "$1" in
-    configure)
-        if ! getent group coredns-docker >/dev/null; then
-            addgroup --system coredns-docker
-        fi
+configure)
+  if ! getent group coredns-docker >/dev/null; then
+    addgroup --system coredns-docker
+  fi
 
-        if ! getent passwd coredns-docker >/dev/null; then
-            adduser --system \
-                --no-create-home \
-                --ingroup coredns-docker \
-                --shell /usr/sbin/nologin \
-                coredns-docker
-        fi
+  if ! getent passwd coredns-docker >/dev/null; then
+    adduser --system \
+      --no-create-home \
+      --ingroup coredns-docker \
+      --shell /usr/sbin/nologin \
+      coredns-docker
+  fi
 
-        if getent group docker >/dev/null; then
-            adduser coredns-docker docker >/dev/null || true
-        fi
+  if getent group docker >/dev/null; then
+    adduser coredns-docker docker >/dev/null || true
+  fi
 
-        if [ -d /etc/coredns ]; then
-            chown root:coredns-docker /etc/coredns
-            chmod 0750 /etc/coredns
-        fi
+  if [ -d /etc/coredns ]; then
+    chown root:coredns-docker /etc/coredns
+    chmod 0750 /etc/coredns
+  fi
 
-        if [ -f /etc/coredns/Corefile ]; then
-            chown root:coredns-docker /etc/coredns/Corefile
-            chmod 0640 /etc/coredns/Corefile
-        fi
-        ;;
+  if [ -f /etc/coredns/Corefile ]; then
+    chown root:coredns-docker /etc/coredns/Corefile
+    chmod 0640 /etc/coredns/Corefile
+  fi
+  ;;
 esac
 
 if [ -d /run/systemd/system ]; then
-    systemctl --system daemon-reload >/dev/null || true
+  systemctl --system daemon-reload >/dev/null || true
 fi
 
 if [ -x /usr/bin/deb-systemd-helper ]; then
-    deb-systemd-helper unmask coredns-docker.service >/dev/null || true
+  deb-systemd-helper unmask coredns-docker.service >/dev/null || true
 
-    if deb-systemd-helper --quiet was-enabled coredns-docker.service; then
-        deb-systemd-helper enable coredns-docker.service >/dev/null || true
-    else
-        deb-systemd-helper update-state coredns-docker.service >/dev/null || true
-    fi
+  if deb-systemd-helper --quiet was-enabled coredns-docker.service; then
+    deb-systemd-helper enable coredns-docker.service >/dev/null || true
+  else
+    deb-systemd-helper update-state coredns-docker.service >/dev/null || true
+  fi
 fi
 
 if [ -d /run/systemd/system ]; then
-    if [ -n "$2" ]; then
-        deb-systemd-invoke try-restart coredns-docker.service >/dev/null || true
-    else
-        deb-systemd-invoke start coredns-docker.service >/dev/null || true
-    fi
+  if [ -n "$2" ]; then
+    deb-systemd-invoke try-restart coredns-docker.service >/dev/null || true
+  else
+    deb-systemd-invoke start coredns-docker.service >/dev/null || true
+  fi
 fi
 
 exit 0

--- a/packaging/postrm
+++ b/packaging/postrm
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+fi
+
+if [ "$1" = remove ]; then
+    if [ -x /usr/bin/deb-systemd-helper ]; then
+        deb-systemd-helper mask coredns-docker.service >/dev/null || true
+    fi
+fi
+
+if [ "$1" = purge ]; then
+    if [ -x /usr/bin/deb-systemd-helper ]; then
+        deb-systemd-helper purge coredns-docker.service >/dev/null || true
+        deb-systemd-helper unmask coredns-docker.service >/dev/null || true
+    fi
+
+    rm -rf /etc/coredns
+
+    if getent passwd coredns-docker >/dev/null; then
+        deluser --system coredns-docker >/dev/null || true
+    fi
+
+    if getent group coredns-docker >/dev/null; then
+        delgroup --system coredns-docker >/dev/null || true
+    fi
+fi
+
+exit 0

--- a/packaging/postrm
+++ b/packaging/postrm
@@ -2,30 +2,30 @@
 set -e
 
 if [ -d /run/systemd/system ]; then
-    systemctl --system daemon-reload >/dev/null || true
+  systemctl --system daemon-reload >/dev/null || true
 fi
 
 if [ "$1" = remove ]; then
-    if [ -x /usr/bin/deb-systemd-helper ]; then
-        deb-systemd-helper mask coredns-docker.service >/dev/null || true
-    fi
+  if [ -x /usr/bin/deb-systemd-helper ]; then
+    deb-systemd-helper mask coredns-docker.service >/dev/null || true
+  fi
 fi
 
 if [ "$1" = purge ]; then
-    if [ -x /usr/bin/deb-systemd-helper ]; then
-        deb-systemd-helper purge coredns-docker.service >/dev/null || true
-        deb-systemd-helper unmask coredns-docker.service >/dev/null || true
-    fi
+  if [ -x /usr/bin/deb-systemd-helper ]; then
+    deb-systemd-helper purge coredns-docker.service >/dev/null || true
+    deb-systemd-helper unmask coredns-docker.service >/dev/null || true
+  fi
 
-    rm -rf /etc/coredns
+  rm -rf /etc/coredns
 
-    if getent passwd coredns-docker >/dev/null; then
-        deluser --system coredns-docker >/dev/null || true
-    fi
+  if getent passwd coredns-docker >/dev/null; then
+    deluser --system coredns-docker >/dev/null || true
+  fi
 
-    if getent group coredns-docker >/dev/null; then
-        delgroup --system coredns-docker >/dev/null || true
-    fi
+  if getent group coredns-docker >/dev/null; then
+    delgroup --system coredns-docker >/dev/null || true
+  fi
 fi
 
 exit 0

--- a/packaging/prerm
+++ b/packaging/prerm
@@ -2,7 +2,7 @@
 set -e
 
 if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
-    deb-systemd-invoke stop coredns-docker.service >/dev/null || true
+  deb-systemd-invoke stop coredns-docker.service >/dev/null || true
 fi
 
 exit 0

--- a/packaging/prerm
+++ b/packaging/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+    deb-systemd-invoke stop coredns-docker.service >/dev/null || true
+fi
+
+exit 0

--- a/packaging/test-lifecycle.sh
+++ b/packaging/test-lifecycle.sh
@@ -59,7 +59,7 @@ sudo apt-get install -y "$DEB"
 
 echo "==> Files installed"
 assert "test -x /usr/bin/coredns-docker"
-assert "test -f /etc/coredns/Corefile"
+assert "sudo test -f /etc/coredns/Corefile"
 assert "test -f /lib/systemd/system/coredns-docker.service"
 
 echo "==> User/group created and added to docker group"
@@ -97,7 +97,7 @@ refute "test -f /usr/bin/coredns-docker"
 refute "test -f /lib/systemd/system/coredns-docker.service"
 refute "systemctl is-active --quiet coredns-docker.service"
 # Conffile and user are preserved on remove
-assert "test -f /etc/coredns/Corefile"
+assert "sudo test -f /etc/coredns/Corefile"
 assert "getent passwd coredns-docker >/dev/null"
 
 echo "==> apt purge"

--- a/packaging/test-lifecycle.sh
+++ b/packaging/test-lifecycle.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 DEB="${1:?usage: $0 path/to/coredns-docker.deb}"
 
 if [ ! -f "$DEB" ]; then
-    echo "deb not found: $DEB" >&2
-    exit 2
+  echo "deb not found: $DEB" >&2
+  exit 2
 fi
 
 # Convert to absolute path - apt-get insists on a leading "./" or "/" for a local file.
@@ -18,25 +18,33 @@ DEB="$(readlink -f "$DEB")"
 export DEBIAN_FRONTEND=noninteractive
 
 dump_logs() {
-    echo "==== service status ===="
-    systemctl --no-pager status coredns-docker.service || true
-    echo "==== service journal ===="
-    journalctl --no-pager -u coredns-docker.service || true
+  echo "==== service status ===="
+  systemctl --no-pager status coredns-docker.service || true
+  echo "==== service journal ===="
+  journalctl --no-pager -u coredns-docker.service || true
 }
-trap 'rc=$?; if [ $rc -ne 0 ]; then dump_logs; fi; exit $rc' EXIT
+
+on_exit() {
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    dump_logs
+  fi
+  exit "$rc"
+}
+trap on_exit EXIT
 
 assert() {
-    if ! eval "$1"; then
-        echo "ASSERT FAILED: $1" >&2
-        exit 1
-    fi
+  if ! eval "$1"; then
+    echo "ASSERT FAILED: $1" >&2
+    exit 1
+  fi
 }
 
 refute() {
-    if eval "$1"; then
-        echo "REFUTE FAILED (expected to fail): $1" >&2
-        exit 1
-    fi
+  if eval "$1"; then
+    echo "REFUTE FAILED (expected to fail): $1" >&2
+    exit 1
+  fi
 }
 
 echo "==> Preflight: docker daemon must be active"
@@ -64,8 +72,8 @@ assert "systemctl is-enabled --quiet coredns-docker.service"
 
 echo "==> Wait up to 30s for service to become active"
 for _ in $(seq 1 30); do
-    if systemctl is-active --quiet coredns-docker.service; then break; fi
-    sleep 1
+  if systemctl is-active --quiet coredns-docker.service; then break; fi
+  sleep 1
 done
 assert "systemctl is-active --quiet coredns-docker.service"
 

--- a/packaging/test-lifecycle.sh
+++ b/packaging/test-lifecycle.sh
@@ -85,7 +85,7 @@ done
 assert "ss -uln | grep -qF ':1053'"
 
 echo "==> Synthetic SOA query succeeds"
-SOA="$(dig +short @127.0.0.1 -p 1053 docker.localhost SOA)"
+SOA="$(dig +short @127.0.0.1 -p 1053 docker. SOA)"
 echo "    SOA: $SOA"
 assert "[ -n \"$SOA\" ]"
 

--- a/packaging/test-lifecycle.sh
+++ b/packaging/test-lifecycle.sh
@@ -77,8 +77,12 @@ for _ in $(seq 1 30); do
 done
 assert "systemctl is-active --quiet coredns-docker.service"
 
-echo "==> Service is bound to UDP/1053"
-assert "ss -uln | awk '{print \$5}' | grep -qE ':1053\$'"
+echo "==> Wait up to 30s for service to bind UDP/1053"
+for _ in $(seq 1 30); do
+  if ss -uln | grep -qF ':1053'; then break; fi
+  sleep 1
+done
+assert "ss -uln | grep -qF ':1053'"
 
 echo "==> Synthetic SOA query succeeds"
 SOA="$(dig +short @127.0.0.1 -p 1053 docker.localhost SOA)"

--- a/packaging/test-lifecycle.sh
+++ b/packaging/test-lifecycle.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Exercise the install -> start -> remove -> purge lifecycle of the .deb.
+# Requires: a Debian-flavored host with apt, systemd, and a running docker daemon.
+# Usage: packaging/test-lifecycle.sh path/to/coredns-docker_<ver>_<arch>.deb
+
+set -euo pipefail
+
+DEB="${1:?usage: $0 path/to/coredns-docker.deb}"
+
+if [ ! -f "$DEB" ]; then
+    echo "deb not found: $DEB" >&2
+    exit 2
+fi
+
+# Convert to absolute path - apt-get insists on a leading "./" or "/" for a local file.
+DEB="$(readlink -f "$DEB")"
+
+export DEBIAN_FRONTEND=noninteractive
+
+dump_logs() {
+    echo "==== service status ===="
+    systemctl --no-pager status coredns-docker.service || true
+    echo "==== service journal ===="
+    journalctl --no-pager -u coredns-docker.service || true
+}
+trap 'rc=$?; if [ $rc -ne 0 ]; then dump_logs; fi; exit $rc' EXIT
+
+assert() {
+    if ! eval "$1"; then
+        echo "ASSERT FAILED: $1" >&2
+        exit 1
+    fi
+}
+
+refute() {
+    if eval "$1"; then
+        echo "REFUTE FAILED (expected to fail): $1" >&2
+        exit 1
+    fi
+}
+
+echo "==> Preflight: docker daemon must be active"
+sudo systemctl is-active --quiet docker.service
+
+echo "==> Install dnsutils for the DNS smoke test"
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends dnsutils iproute2
+
+echo "==> Install $DEB"
+sudo apt-get install -y "$DEB"
+
+echo "==> Files installed"
+assert "test -x /usr/bin/coredns-docker"
+assert "test -f /etc/coredns/Corefile"
+assert "test -f /lib/systemd/system/coredns-docker.service"
+
+echo "==> User/group created and added to docker group"
+assert "getent passwd coredns-docker >/dev/null"
+assert "getent group coredns-docker >/dev/null"
+assert "id -nG coredns-docker | tr ' ' '\n' | grep -qx docker"
+
+echo "==> Unit is enabled"
+assert "systemctl is-enabled --quiet coredns-docker.service"
+
+echo "==> Wait up to 30s for service to become active"
+for _ in $(seq 1 30); do
+    if systemctl is-active --quiet coredns-docker.service; then break; fi
+    sleep 1
+done
+assert "systemctl is-active --quiet coredns-docker.service"
+
+echo "==> Service is bound to UDP/1053"
+assert "ss -uln | awk '{print \$5}' | grep -qE ':1053\$'"
+
+echo "==> Synthetic SOA query succeeds"
+SOA="$(dig +short @127.0.0.1 -p 1053 docker.localhost SOA)"
+echo "    SOA: $SOA"
+assert "[ -n \"$SOA\" ]"
+
+echo "==> Ordering: After=docker.service and Before=nginx.service"
+systemctl show coredns-docker.service --property=After --property=Before | tee /tmp/coredns-ordering
+assert "grep -q '^After=.*docker.service' /tmp/coredns-ordering"
+assert "grep -q '^Before=.*nginx.service' /tmp/coredns-ordering"
+
+echo "==> apt remove"
+sudo apt-get remove -y coredns-docker
+
+refute "test -f /usr/bin/coredns-docker"
+refute "test -f /lib/systemd/system/coredns-docker.service"
+refute "systemctl is-active --quiet coredns-docker.service"
+# Conffile and user are preserved on remove
+assert "test -f /etc/coredns/Corefile"
+assert "getent passwd coredns-docker >/dev/null"
+
+echo "==> apt purge"
+sudo apt-get purge -y coredns-docker
+
+refute "test -d /etc/coredns"
+refute "getent passwd coredns-docker >/dev/null"
+refute "getent group coredns-docker >/dev/null"
+
+echo "==> Lifecycle test passed"
+trap - EXIT


### PR DESCRIPTION
The deb now ships a default Corefile, a hardened systemd unit, and maintainer scripts that create a dedicated `coredns-docker` system user, enable the unit, and start it after `docker.service` and before `nginx.service`. `apt purge` removes the unit, the Corefile directory, and the user, leaving the host as if the package had never been installed.

CI now exercises the install -> start -> remove -> purge cycle on the freshly-built amd64 deb so future regressions in the maintainer scripts or unit file are caught at PR time.