### PR TITLE
feat: add name_from_labels Corefile directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ validation/*
 
 # Local test binary
 coredns-docker-local
+
+# Scratch space
+tmp/

--- a/Corefile.example
+++ b/Corefile.example
@@ -12,6 +12,9 @@ docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
         max_backoff 30s
         networks bridge my-custom-network
         zone  docker.localhost
+        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+        name_from_labels "{{label \"com.dokku.app-name\"}}"
+        name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
     }
     prometheus :9153
     cache 30

--- a/Corefile.example
+++ b/Corefile.example
@@ -12,9 +12,9 @@ docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
         max_backoff 30s
         networks bridge my-custom-network
         zone  docker.localhost
-        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
-        name_from_labels "{{label \"com.dokku.app-name\"}}"
-        name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
+        name_from_labels "{{if and (hasLabel \"com.dokku.app-name\") (hasLabel \"com.dokku.process-type\")}}{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}{{end}}"
+        name_from_labels "{{if hasLabel \"com.dokku.app-name\"}}{{label \"com.dokku.app-name\"}}{{end}}"
+        name_from_labels "{{if and (hasLabel \"com.docker.compose.project\") (hasLabel \"com.docker.compose.service\")}}{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}{{end}}"
     }
     prometheus :9153
     cache 30

--- a/docker.go
+++ b/docker.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -38,14 +39,15 @@ type Docker struct {
 
 	Fall fall.F
 
-	ttl         uint32
-	client      *client.Client
-	zones       []string
-	labelPrefix string
-	maxBackoff  time.Duration
-	networks    []string
-	hostMode    bool
-	hostModePTR bool
+	ttl           uint32
+	client        *client.Client
+	zones         []string
+	labelPrefix   string
+	maxBackoff    time.Duration
+	networks      []string
+	hostMode      bool
+	hostModePTR   bool
+	nameTemplates []*template.Template
 
 	mu           sync.RWMutex
 	records      map[string][]net.IP
@@ -428,13 +430,14 @@ func (d *Docker) syncRecords(ctx context.Context) {
 	log.Debugf("Found %d running containers", len(containers))
 
 	newRecords, newSrvs, newPtrs, newCnames, newTxts := generateRecords(ctx, GenerateRecordsInput{
-		Containers:  containers,
-		Zones:       d.zones,
-		Inspector:   d.client,
-		LabelPrefix: d.labelPrefix,
-		Networks:    d.networks,
-		HostMode:    d.hostMode,
-		HostModePTR: d.hostModePTR,
+		Containers:    containers,
+		Zones:         d.zones,
+		Inspector:     d.client,
+		LabelPrefix:   d.labelPrefix,
+		Networks:      d.networks,
+		HostMode:      d.hostMode,
+		HostModePTR:   d.hostModePTR,
+		NameTemplates: d.nameTemplates,
 	})
 
 	d.mu.Lock()
@@ -481,6 +484,12 @@ type GenerateRecordsInput struct {
 	// Off by default because multiple containers may share a host IP
 	// (especially the loopback fallback), making reverse lookups noisy.
 	HostModePTR bool
+	// NameTemplates are Go text/templates that synthesize additional
+	// names for each container from its Docker labels. Each template is
+	// evaluated independently per container and any non-empty result
+	// joins the container's name set alongside container name, network
+	// aliases, DNSNames, Compose project.service, and hostname labels.
+	NameTemplates []*template.Template
 }
 
 // unescapeTxtCharString processes RFC 1035 §5.1 character-string
@@ -655,6 +664,13 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 			}
 		}
 
+		// Render every configured name_from_labels template against this
+		// container's labels. Results join the same name set as container
+		// name, network aliases, DNSNames, Compose project.service, and
+		// hostname-label names; the existing case-insensitive dedup below
+		// drops overlap.
+		templatedNames := renderNameTemplates(input.NameTemplates, baseName, c.ID, inspect.Config.Labels)
+
 		// Parse wildcard label
 		wildcardLabel := input.LabelPrefix + "/wildcard"
 		if input.LabelPrefix == "" {
@@ -729,6 +745,7 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 				names = append(names, project+"."+service)
 			}
 			names = append(names, hostnameNames...)
+			names = append(names, templatedNames...)
 
 			seen := make(map[string]bool, len(names))
 			uniqueNames := names[:0]
@@ -827,6 +844,7 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 				names = append(names, project+"."+service)
 			}
 			names = append(names, hostnameNames...)
+			names = append(names, templatedNames...)
 
 			// Deduplicate names (same rules as the default path).
 			seen := make(map[string]bool, len(names))
@@ -1069,6 +1087,7 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 			}
 
 			names = append(names, hostnameNames...)
+			names = append(names, templatedNames...)
 
 			// Deduplicate names (case-insensitive, preserving insertion order) to
 			// avoid producing duplicate records when a container's name overlaps

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,61 @@ Containers attached only to networks **not** in the list are ignored, even if th
 
 See [examples/08-network-filtering](examples/08-network-filtering) for a runnable setup.
 
+## `name_from_labels`
+
+Synthesize additional DNS names for each container from its Docker labels. The directive is repeatable -- each line is one Go [`text/template`](https://pkg.go.dev/text/template) body, evaluated independently per container, and any non-empty result joins the container's name set alongside the container name, network aliases, DNSNames, Compose `project.service`, and `hostname` labels. The existing case-insensitive name dedup applies, so multiple templates that resolve to the same string per container are folded into one.
+
+**Why this exists:** Docker's built-in default names (container name, network aliases, DNSNames, Compose `project.service`) cover many setups, but orchestrators like Dokku, Nomad, and custom schedulers stamp their own labels on every container. Without `name_from_labels`, you would have to add a separate `com.dokku.coredns-docker/hostname` label to every container to get a stable, multi-instance DNS name. With it, three containers sharing a label combination automatically collapse onto a single multi-A record name -- producing standard DNS round-robin without per-container configuration.
+
+The shipped `packaging/Corefile` already includes three defaults:
+
+```text
+docker {
+    zone docker.
+    name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+    name_from_labels "{{label \"com.dokku.app-name\"}}"
+    name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
+}
+```
+
+Out of the box this turns three Dokku web dynos with the same `com.dokku.app-name=docs` and `com.dokku.process-type=web` labels into a single `docs.web.<zone>.` RRSet of three IPs, plus `docs.<zone>.` covering every container in the same app, plus the long-standing Compose `project.service` collapse for `docker compose up --scale`.
+
+### Template helpers
+
+Each template runs against a small data context. Most operators reach for one of these custom funcs because Docker label keys typically contain dots and cannot be reached via Go template field access:
+
+| Helper | Effect |
+| --- | --- |
+| `label "KEY"` | Returns the label value (with surrounding whitespace trimmed). If the label is missing or empty, the template aborts and contributes no name for this container. |
+| `labelOr "KEY" "DEFAULT"` | Returns the label value, or the supplied default if the label is missing or empty. Useful for fallbacks that should still render. |
+| `hasLabel "KEY"` | Boolean for use inside `{{if}}` or `{{with}}` blocks. |
+
+`.Labels` (the full map), `.Name` (container name without leading slash), and `.ID` (the container ID) are also available on the data context for advanced use.
+
+### Quoting
+
+The Caddyfile lexer the Corefile uses recognizes only double-quoted strings. Because the template body itself contains the double-quoted label keys, the outer string must escape them. Both Dokku examples above are equivalent to writing this template body:
+
+```text
+{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}
+```
+
+### When a template aborts
+
+If `label "KEY"` is called for a label the container does not carry (or whose value is empty after trimming), the template execution aborts with a `template: ... missing or empty` error. The plugin catches this and treats it as "this template contributes no name for this container." Other templates and other name sources are unaffected. This is also the safest way to scope a template to a subset of containers: reference the labels that mark the subset, and the plugin will skip every container that does not carry them.
+
+### Conditionals and fallbacks
+
+For more complex behavior, combine the helpers with standard Go template control flow. For example, to register a container under both `<app>.<process>` and `<app>` when `process-type` is set, but just `<app>` when it is not:
+
+```text
+name_from_labels "{{if hasLabel \"com.dokku.process-type\"}}{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}{{else}}{{label \"com.dokku.app-name\"}}{{end}}"
+```
+
+### Upgrade note for the package
+
+Debian packages do not overwrite the operator's existing `/etc/coredns/Corefile` (it is a conffile). On an upgrade from a pre-`name_from_labels` version, your existing Corefile is preserved and you do not get the new defaults automatically. Paste the three lines above into your `docker { ... }` block to opt in.
+
 ## `fallthrough`
 
 Instead of returning NXDOMAIN for unmatched names, pass the query to the next plugin in the chain. Without arguments, fallthrough applies to every unmatched name. With arguments, it applies only to the listed zones.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,18 +126,18 @@ Synthesize additional DNS names for each container from its Docker labels. The d
 
 **Why this exists:** Docker's built-in default names (container name, network aliases, DNSNames, Compose `project.service`) cover many setups, but orchestrators like Dokku, Nomad, and custom schedulers stamp their own labels on every container. Without `name_from_labels`, you would have to add a separate `com.dokku.coredns-docker/hostname` label to every container to get a stable, multi-instance DNS name. With it, three containers sharing a label combination automatically collapse onto a single multi-A record name -- producing standard DNS round-robin without per-container configuration.
 
-The shipped `packaging/Corefile` already includes three defaults:
+The shipped `packaging/Corefile` already includes three defaults, each gated on `hasLabel` so containers that do not carry the referenced labels render empty (and are cleanly skipped) instead of producing a debug log line per template per sync:
 
 ```text
 docker {
     zone docker.
-    name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
-    name_from_labels "{{label \"com.dokku.app-name\"}}"
-    name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
+    name_from_labels "{{if and (hasLabel \"com.dokku.app-name\") (hasLabel \"com.dokku.process-type\")}}{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}{{end}}"
+    name_from_labels "{{if hasLabel \"com.dokku.app-name\"}}{{label \"com.dokku.app-name\"}}{{end}}"
+    name_from_labels "{{if and (hasLabel \"com.docker.compose.project\") (hasLabel \"com.docker.compose.service\")}}{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}{{end}}"
 }
 ```
 
-Out of the box this turns three Dokku web dynos with the same `com.dokku.app-name=docs` and `com.dokku.process-type=web` labels into a single `docs.web.<zone>.` RRSet of three IPs, plus `docs.<zone>.` covering every container in the same app, plus the long-standing Compose `project.service` collapse for `docker compose up --scale`.
+Out of the box this turns three Dokku web dynos with the same `com.dokku.app-name=docs` and `com.dokku.process-type=web` labels into a single `docs.web.<zone>.` RRSet of three IPs, plus `docs.<zone>.` covering every container in the same app, plus the long-standing Compose `project.service` collapse for `docker compose up --scale`. Containers that carry none of these labels (e.g., a stock `nginx:alpine`) render empty for every shipped template and contribute nothing extra.
 
 ### Template helpers
 
@@ -161,7 +161,7 @@ The Caddyfile lexer the Corefile uses recognizes only double-quoted strings. Bec
 
 ### When a template aborts
 
-If `label "KEY"` is called for a label the container does not carry (or whose value is empty after trimming), the template execution aborts with a `template: ... missing or empty` error. The plugin catches this and treats it as "this template contributes no name for this container." Other templates and other name sources are unaffected. This is also the safest way to scope a template to a subset of containers: reference the labels that mark the subset, and the plugin will skip every container that does not carry them.
+If `label "KEY"` is called for a label the container does not carry (or whose value is empty after trimming), the template execution aborts with a `template: ... missing or empty` error. The plugin catches this and treats it as "this template contributes no name for this container." Other templates and other name sources are unaffected. This is one safe way to scope a template to a subset of containers, but on a host with many containers that do not carry the referenced labels, every aborted execution emits a debug log line per template per sync. To avoid that noise, the shipped defaults gate each `label` call on `hasLabel` so the template renders empty (which the plugin filters silently) instead of aborting. Choose either pattern based on whether you want the abort visibility or the silent-skip cleanliness.
 
 ### Conditionals and fallbacks
 

--- a/docs/coredns-plugin-summary.md
+++ b/docs/coredns-plugin-summary.md
@@ -27,6 +27,7 @@ docker {
     networks NETWORK [NETWORK...]
     fallthrough [ZONES...]
     host_mode [ptr]
+    name_from_labels TEMPLATE
 }
 ~~~
 
@@ -37,6 +38,7 @@ docker {
 * `networks` **NETWORK [NETWORK...]** whitelists the Docker networks the plugin serves. Containers attached only to non-whitelisted networks are ignored. If omitted, every network is served.
 * `fallthrough` **[ZONES...]** If a query for a record in the zones for which the plugin is authoritative results in NXDOMAIN, normally that is what the response will be. However, if this option is specified, the query will instead be passed on down the plugin chain. If **[ZONES...]** is omitted, fallthrough happens for all zones for which the plugin is authoritative.
 * `host_mode` **[ptr]** resolves container names to the host IP and host port of each container's port bindings instead of the container's internal network IP. With the optional `ptr` flag, PTR records are also generated for host IPs (off by default to reduce reverse-lookup noise).
+* `name_from_labels` **TEMPLATE** registers an additional name source from a Go `text/template`. The directive is repeatable; each line is one template, evaluated independently per container. Templates can call `label "KEY"` (returns the value or aborts the template), `labelOr "KEY" "DEFAULT"`, and `hasLabel "KEY"`. A template that aborts contributes no name for that container. Multiple templates collapse onto the same FQDN when they render to identical strings, producing standard multi-A round-robin responses without per-container labels.
 
 ## Name Sources
 
@@ -45,7 +47,8 @@ Without any labels, every container automatically receives A/AAAA records for:
 * the container name set via `docker run --name` or `container_name:` in Compose,
 * Docker network aliases,
 * Docker-internal DNS names,
-* the `project.service` pair for containers managed by Docker Compose.
+* the `project.service` pair for containers managed by Docker Compose,
+* any names produced by `name_from_labels` templates configured in the Corefile (the shipped `packaging/Corefile` enables Dokku `<app>.<process>` and `<app>` plus the Compose `<project>.<service>` collapse).
 
 PTR records pointing back to these names are generated for both IPv4 (`in-addr.arpa.`) and IPv6 (`ip6.arpa.`) reverse zones. To serve reverse lookups the reverse zones must be listed in the CoreDNS server block so that CoreDNS delivers PTR queries to the plugin:
 

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -10,8 +10,11 @@ Before you touch any labels, the plugin already creates A/AAAA records for the n
 - Docker **network aliases** (`--network-alias`).
 - The **DNS names** Docker itself exposes via the Docker engine.
 - The Docker Compose `project.service` pair (e.g., `myproject.web` when Compose stack `myproject` has a service named `web`).
+- Any names produced by [`name_from_labels`](configuration.md#name_from_labels) templates configured in the Corefile. The shipped `packaging/Corefile` includes templates for Dokku (`<app>.<process>` and `<app>`) and Compose (`<project>.<service>`), so a `docker run` carrying the matching labels gets those names without any plugin labels of your own.
 
 All of those names become A/AAAA records under your configured zone. PTR records for the reverse lookup are created as well (see [Configuration: reverse zones](configuration.md#reverse-zones-ptr-records)). You only need labels when you want records the default name set does not cover, or when you want SRV/TXT/CNAME/wildcard records.
+
+When the same name comes from more than one container -- for example, three containers all carrying the same Compose `service`, the same `--network-alias`, or the same Dokku `app-name` + `process-type` pair -- the plugin returns all of their IPs in a single multi-A response. Clients see this as standard DNS round-robin.
 
 ## `hostname` labels
 

--- a/docs/examples/11-name-from-labels/Corefile
+++ b/docs/examples/11-name-from-labels/Corefile
@@ -1,0 +1,9 @@
+docker.:1053 in-addr.arpa:1053 ip6.arpa:1053 {
+    errors
+    log
+    docker {
+        zone docker.
+        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+        name_from_labels "{{label \"com.dokku.app-name\"}}"
+    }
+}

--- a/docs/examples/11-name-from-labels/docker-compose.yml
+++ b/docs/examples/11-name-from-labels/docker-compose.yml
@@ -1,0 +1,36 @@
+# name_from_labels example: collapse multiple containers onto one DNS name
+# using labels they already carry, without a custom plugin label.
+#
+# Start CoreDNS:
+#   coredns-docker -conf Corefile
+# Start the three containers:
+#   docker compose up -d
+#
+# Verify the multi-A response (three IPs in one answer):
+#   dig @127.0.0.1 -p 1053 docs.web.docker +short
+#   dig @127.0.0.1 -p 1053 docs.docker +short
+#
+# Per-container names still resolve to a single IP each:
+#   dig @127.0.0.1 -p 1053 docs-web-1.docker +short
+
+name: name-from-labels-example
+
+services:
+  web1:
+    image: nginx:alpine
+    container_name: docs-web-1
+    labels:
+      com.dokku.app-name: "docs"
+      com.dokku.process-type: "web"
+  web2:
+    image: nginx:alpine
+    container_name: docs-web-2
+    labels:
+      com.dokku.app-name: "docs"
+      com.dokku.process-type: "web"
+  web3:
+    image: nginx:alpine
+    container_name: docs-web-3
+    labels:
+      com.dokku.app-name: "docs"
+      com.dokku.process-type: "web"

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -42,4 +42,5 @@ Each directory in this folder is a runnable demonstration of a specific feature.
 | [08-network-filtering](08-network-filtering) | `networks` whitelist ignoring containers on other networks |
 | [09-multiple-zones](09-multiple-zones) | Serving multiple zones from one Corefile |
 | [10-fallthrough](10-fallthrough) | `fallthrough` to the `forward` plugin for upstream resolution |
+| [11-name-from-labels](11-name-from-labels) | `name_from_labels` collapsing multiple containers onto a single multi-A name |
 | [nginx-integration](nginx-integration) | nginx reverse proxy resolving backends via CoreDNS |

--- a/e2e.bats
+++ b/e2e.bats
@@ -987,3 +987,175 @@ EOF
   wait "$HOSTMODE_PID" 2>/dev/null || true
   rm -f "$HOSTMODE_COREFILE"
 }
+
+@test "[e2e] name_from_labels: shared dokku labels produce a multi-IP RRSet" {
+  local NFL_COREFILE
+  NFL_COREFILE="$(mktemp /tmp/Corefile.nfl.XXXXXX)"
+  local NFL_PORT=15359
+  cat >"$NFL_COREFILE" <<EOF
+docker.localhost:${NFL_PORT} in-addr.arpa:${NFL_PORT} ip6.arpa:${NFL_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone docker.localhost
+        ttl 10
+        networks bridge ${TEST_NETWORK}
+        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+        name_from_labels "{{label \"com.dokku.app-name\"}}"
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$NFL_COREFILE" &
+  local NFL_PID=$!
+
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$NFL_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  docker run -d --name coredns-e2e-nfl-web1 --network bridge \
+    --label "com.dokku.app-name=docs" \
+    --label "com.dokku.process-type=web" \
+    alpine sleep 3600
+  docker run -d --name coredns-e2e-nfl-web2 --network bridge \
+    --label "com.dokku.app-name=docs" \
+    --label "com.dokku.process-type=web" \
+    alpine sleep 3600
+  docker run -d --name coredns-e2e-nfl-web3 --network bridge \
+    --label "com.dokku.app-name=docs" \
+    --label "com.dokku.process-type=web" \
+    alpine sleep 3600
+
+  local ip1 ip2 ip3
+  ip1=$(docker inspect -f '{{.NetworkSettings.Networks.bridge.IPAddress}}' coredns-e2e-nfl-web1)
+  ip2=$(docker inspect -f '{{.NetworkSettings.Networks.bridge.IPAddress}}' coredns-e2e-nfl-web2)
+  ip3=$(docker inspect -f '{{.NetworkSettings.Networks.bridge.IPAddress}}' coredns-e2e-nfl-web3)
+
+  # Wait until docs.web.docker.localhost has at least one record before
+  # asserting on the count.
+  run wait_for_record_on_port "docs.web.docker.localhost" "A" "$NFL_PORT"
+  assert_success
+
+  # Re-query and assert all three IPs are present in the RRSet.
+  local merged_output
+  retries=20
+  i=0
+  while [ "$i" -lt "$retries" ]; do
+    merged_output=$(dig +short +time=1 +tries=1 @127.0.0.1 -p "$NFL_PORT" "docs.web.docker.localhost" A 2>/dev/null)
+    local count
+    count=$(echo "$merged_output" | grep -c '^[0-9]' || true)
+    if [ "$count" = "3" ]; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  echo "merged_output: $merged_output"
+  [[ "$merged_output" == *"$ip1"* ]] || flunk "missing $ip1 in docs.web RRSet: $merged_output"
+  [[ "$merged_output" == *"$ip2"* ]] || flunk "missing $ip2 in docs.web RRSet: $merged_output"
+  [[ "$merged_output" == *"$ip3"* ]] || flunk "missing $ip3 in docs.web RRSet: $merged_output"
+
+  # The single-label template (just app-name) collects the same set.
+  retries=20
+  i=0
+  while [ "$i" -lt "$retries" ]; do
+    merged_output=$(dig +short +time=1 +tries=1 @127.0.0.1 -p "$NFL_PORT" "docs.docker.localhost" A 2>/dev/null)
+    local count
+    count=$(echo "$merged_output" | grep -c '^[0-9]' || true)
+    if [ "$count" = "3" ]; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  [[ "$merged_output" == *"$ip1"* ]] || flunk "missing $ip1 in docs RRSet: $merged_output"
+  [[ "$merged_output" == *"$ip2"* ]] || flunk "missing $ip2 in docs RRSet: $merged_output"
+  [[ "$merged_output" == *"$ip3"* ]] || flunk "missing $ip3 in docs RRSet: $merged_output"
+
+  # Per-container names still resolve to exactly one IP each.
+  run wait_for_record_on_port "coredns-e2e-nfl-web1.docker.localhost" "A" "$NFL_PORT"
+  assert_success
+  assert_equal "$ip1" "$output"
+
+  # Cleanup
+  docker rm -f coredns-e2e-nfl-web1 coredns-e2e-nfl-web2 coredns-e2e-nfl-web3
+  kill "$NFL_PID" 2>/dev/null || true
+  wait "$NFL_PID" 2>/dev/null || true
+  rm -f "$NFL_COREFILE"
+}
+
+@test "[e2e] name_from_labels: container missing referenced label is skipped" {
+  local NFL_COREFILE
+  NFL_COREFILE="$(mktemp /tmp/Corefile.nfl.XXXXXX)"
+  local NFL_PORT=15360
+  cat >"$NFL_COREFILE" <<EOF
+docker.localhost:${NFL_PORT} in-addr.arpa:${NFL_PORT} ip6.arpa:${NFL_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone docker.localhost
+        ttl 10
+        networks bridge ${TEST_NETWORK}
+        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$NFL_COREFILE" &
+  local NFL_PID=$!
+
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$NFL_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  # Container with both labels — should register under api.web.docker.localhost.
+  docker run -d --name coredns-e2e-nfl-skipfull --network bridge \
+    --label "com.dokku.app-name=api" \
+    --label "com.dokku.process-type=web" \
+    alpine sleep 3600
+
+  # Container with only one of the labels — should NOT contribute to any
+  # templated FQDN.
+  docker run -d --name coredns-e2e-nfl-skipone --network bridge \
+    --label "com.dokku.app-name=api" \
+    alpine sleep 3600
+
+  local ip_full
+  ip_full=$(docker inspect -f '{{.NetworkSettings.Networks.bridge.IPAddress}}' coredns-e2e-nfl-skipfull)
+
+  run wait_for_record_on_port "api.web.docker.localhost" "A" "$NFL_PORT"
+  assert_success
+  assert_equal "$ip_full" "$output"
+
+  # Confirm that api.web.docker.localhost does not also include the
+  # one-labeled container's IP. It should be a single-IP answer.
+  run dig +short +time=2 +tries=1 @127.0.0.1 -p "$NFL_PORT" "api.web.docker.localhost" A
+  assert_success
+  local count
+  count=$(echo "$output" | grep -c '^[0-9]' || true)
+  assert_equal "1" "$count"
+
+  # Per-container record for the one-labeled container still resolves.
+  run wait_for_record_on_port "coredns-e2e-nfl-skipone.docker.localhost" "A" "$NFL_PORT"
+  assert_success
+
+  # Cleanup
+  docker rm -f coredns-e2e-nfl-skipfull coredns-e2e-nfl-skipone
+  kill "$NFL_PID" 2>/dev/null || true
+  wait "$NFL_PID" 2>/dev/null || true
+  rm -f "$NFL_COREFILE"
+}

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"net"
 	"reflect"
+	"sort"
 	"testing"
+	"text/template"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -4850,4 +4852,113 @@ func TestGenerateRecords(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateRecordsNameFromLabels(t *testing.T) {
+	mustTmpl := func(body string) *template.Template {
+		tmpl, err := parseNameTemplate(body)
+		if err != nil {
+			t.Fatalf("parseNameTemplate(%q): %v", body, err)
+		}
+		return tmpl
+	}
+
+	makeContainer := func(name, ip string, labels map[string]string) (string, container.InspectResponse) {
+		return name, container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				Name: "/" + name,
+				HostConfig: &container.HostConfig{
+					NetworkMode: container.NetworkMode("bridge"),
+				},
+			},
+			Config: &container.Config{Labels: labels},
+			NetworkSettings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{
+					"bridge": {IPAddress: ip},
+				},
+			},
+		}
+	}
+
+	dokkuLabels := func(process string) map[string]string {
+		return map[string]string{
+			"com.dokku.app-name":     "docs",
+			"com.dokku.process-type": process,
+		}
+	}
+
+	id1, c1 := makeContainer("docs.web.1", "172.17.0.4", dokkuLabels("web"))
+	id2, c2 := makeContainer("docs.web.2", "172.17.0.14", dokkuLabels("web"))
+	id3, c3 := makeContainer("docs.web.3", "172.17.0.16", dokkuLabels("web"))
+	id4, c4 := makeContainer("docs.worker.1", "172.17.0.20", dokkuLabels("worker"))
+	id5, c5 := makeContainer("untagged", "172.17.0.30", map[string]string{})
+
+	input := GenerateRecordsInput{
+		Inspector: &mockContainerInspector{
+			inspections: map[string]container.InspectResponse{
+				id1: c1, id2: c2, id3: c3, id4: c4, id5: c5,
+			},
+		},
+		Containers: []container.Summary{
+			{ID: id1}, {ID: id2}, {ID: id3}, {ID: id4}, {ID: id5},
+		},
+		Zones:       []string{"docker."},
+		LabelPrefix: "com.dokku.coredns-docker",
+		NameTemplates: []*template.Template{
+			mustTmpl(`{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}`),
+			mustTmpl(`{{label "com.dokku.app-name"}}`),
+		},
+	}
+
+	records, _, _, _, _ := generateRecords(context.Background(), input)
+
+	assertIPs := func(fqdn string, want ...string) {
+		t.Helper()
+		got, ok := records[fqdn]
+		if !ok {
+			t.Errorf("expected records for %s, none found", fqdn)
+			return
+		}
+		gotStrs := make([]string, len(got))
+		for i, ip := range got {
+			gotStrs[i] = ip.String()
+		}
+		sort.Strings(gotStrs)
+		wantSorted := append([]string(nil), want...)
+		sort.Strings(wantSorted)
+		if !reflect.DeepEqual(gotStrs, wantSorted) {
+			t.Errorf("for %s: got %v, want %v", fqdn, gotStrs, wantSorted)
+		}
+	}
+
+	// docs.web (the {{label app}}.{{label process}} template) collects all
+	// three web dynos.
+	assertIPs("docs.web.docker.", "172.17.0.4", "172.17.0.14", "172.17.0.16")
+
+	// docs (the {{label app}} template) collects every container that
+	// carries the app-name label, which is all four Dokku containers.
+	assertIPs("docs.docker.", "172.17.0.4", "172.17.0.14", "172.17.0.16", "172.17.0.20")
+
+	// docs.worker collects just the worker container.
+	assertIPs("docs.worker.docker.", "172.17.0.20")
+
+	// The untagged container does not contribute to either templated FQDN
+	// (both reference labels it does not carry) but is still reachable
+	// under its container name.
+	if _, ok := records["untagged.docker."]; !ok {
+		t.Errorf("expected per-container record for untagged.docker.")
+	}
+	if ips, ok := records["docs.web.docker."]; ok {
+		for _, ip := range ips {
+			if ip.String() == "172.17.0.30" {
+				t.Errorf("untagged container leaked into docs.web.docker.")
+			}
+		}
+	}
+
+	// Per-container names are unaffected: each docs.web.N still resolves
+	// to exactly its own IP.
+	assertIPs("docs.web.1.docker.", "172.17.0.4")
+	assertIPs("docs.web.2.docker.", "172.17.0.14")
+	assertIPs("docs.web.3.docker.", "172.17.0.16")
 }

--- a/name_template.go
+++ b/name_template.go
@@ -1,0 +1,84 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// nameTemplateData is the data context passed to each name_from_labels
+// template at execution time. Most operators reach for the `label`,
+// `labelOr`, and `hasLabel` helpers because Docker label keys typically
+// contain dots and cannot be reached via Go template field access.
+type nameTemplateData struct {
+	Name   string
+	ID     string
+	Labels map[string]string
+}
+
+// nameTemplateFuncs returns the funcmap stub used at parse time. The
+// real implementations are bound per-execution via Clone()+Funcs() so
+// each container can carry its own labels through the closure.
+func nameTemplateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"label":    func(string) (string, error) { return "", nil },
+		"labelOr":  func(string, string) string { return "" },
+		"hasLabel": func(string) bool { return false },
+	}
+}
+
+// parseNameTemplate parses a Go text/template body for use with the
+// name_from_labels Corefile directive.
+func parseNameTemplate(body string) (*template.Template, error) {
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("template is empty")
+	}
+	return template.New("name_from_labels").Funcs(nameTemplateFuncs()).Parse(body)
+}
+
+// renderNameTemplates evaluates each parsed template against the given
+// container metadata and returns the non-empty rendered names. A
+// template that errors during execution (e.g., a `label` call hits a
+// missing key) contributes no name; other templates and other name
+// sources are unaffected.
+func renderNameTemplates(templates []*template.Template, name, id string, labels map[string]string) []string {
+	if len(templates) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(templates))
+	data := nameTemplateData{Name: name, ID: id, Labels: labels}
+	for _, base := range templates {
+		cloned, err := base.Clone()
+		if err != nil {
+			log.Debugf("name_from_labels template clone failed: %v", err)
+			continue
+		}
+		cloned.Funcs(template.FuncMap{
+			"label": func(k string) (string, error) {
+				v := strings.TrimSpace(labels[k])
+				if v == "" {
+					return "", fmt.Errorf("label %q missing or empty", k)
+				}
+				return v, nil
+			},
+			"labelOr": func(k, def string) string {
+				if v := strings.TrimSpace(labels[k]); v != "" {
+					return v
+				}
+				return def
+			},
+			"hasLabel": func(k string) bool {
+				return strings.TrimSpace(labels[k]) != ""
+			},
+		})
+		var buf strings.Builder
+		if err := cloned.Execute(&buf, data); err != nil {
+			log.Debugf("name_from_labels template skipped: %v", err)
+			continue
+		}
+		if rendered := strings.TrimSpace(buf.String()); rendered != "" {
+			out = append(out, rendered)
+		}
+	}
+	return out
+}

--- a/name_template_test.go
+++ b/name_template_test.go
@@ -98,3 +98,72 @@ func TestParseNameTemplateRejectsEmpty(t *testing.T) {
 		t.Fatal("expected error for whitespace-only template")
 	}
 }
+
+// TestShippedDefaultsAreSilentOnMissingLabels exercises the exact template
+// bodies shipped in packaging/Corefile (after Caddyfile quote-unescaping)
+// to make sure they render empty for unrelated containers instead of
+// aborting and producing a debug log line per template per sync.
+func TestShippedDefaultsAreSilentOnMissingLabels(t *testing.T) {
+	shippedBodies := []string{
+		`{{if and (hasLabel "com.dokku.app-name") (hasLabel "com.dokku.process-type")}}{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}{{end}}`,
+		`{{if hasLabel "com.dokku.app-name"}}{{label "com.dokku.app-name"}}{{end}}`,
+		`{{if and (hasLabel "com.docker.compose.project") (hasLabel "com.docker.compose.service")}}{{label "com.docker.compose.project"}}.{{label "com.docker.compose.service"}}{{end}}`,
+	}
+
+	tmpls := make([]*template.Template, len(shippedBodies))
+	for i, body := range shippedBodies {
+		tmpls[i] = mustParseNameTemplate(t, body)
+	}
+
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   []string
+	}{
+		{
+			name:   "container with no relevant labels renders nothing",
+			labels: map[string]string{"unrelated": "value"},
+			want:   nil,
+		},
+		{
+			name:   "container with empty labels map renders nothing",
+			labels: map[string]string{},
+			want:   nil,
+		},
+		{
+			name: "dokku web dyno collapses onto app.process and app",
+			labels: map[string]string{
+				"com.dokku.app-name":     "docs",
+				"com.dokku.process-type": "web",
+			},
+			want: []string{"docs.web", "docs"},
+		},
+		{
+			name: "dokku container with only app-name produces just the app name",
+			labels: map[string]string{
+				"com.dokku.app-name": "docs",
+			},
+			want: []string{"docs"},
+		},
+		{
+			name: "compose container collapses onto project.service",
+			labels: map[string]string{
+				"com.docker.compose.project": "myproj",
+				"com.docker.compose.service": "web",
+			},
+			want: []string{"myproj.web"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderNameTemplates(tmpls, "container-name", "container-id", tc.labels)
+			if len(got) == 0 {
+				got = nil
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/name_template_test.go
+++ b/name_template_test.go
@@ -1,0 +1,100 @@
+package docker
+
+import (
+	"reflect"
+	"testing"
+	"text/template"
+)
+
+func mustParseNameTemplate(t *testing.T, body string) *template.Template {
+	t.Helper()
+	tmpl, err := parseNameTemplate(body)
+	if err != nil {
+		t.Fatalf("parseNameTemplate(%q): %v", body, err)
+	}
+	return tmpl
+}
+
+func TestRenderNameTemplates(t *testing.T) {
+	tests := []struct {
+		name      string
+		templates []string
+		labels    map[string]string
+		want      []string
+	}{
+		{
+			name:      "single template hits all referenced labels",
+			templates: []string{`{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}`},
+			labels:    map[string]string{"com.dokku.app-name": "docs", "com.dokku.process-type": "web"},
+			want:      []string{"docs.web"},
+		},
+		{
+			name:      "missing label aborts the template",
+			templates: []string{`{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}`},
+			labels:    map[string]string{"com.dokku.app-name": "docs"},
+			want:      nil,
+		},
+		{
+			name:      "empty label value treated as missing",
+			templates: []string{`{{label "com.dokku.app-name"}}`},
+			labels:    map[string]string{"com.dokku.app-name": "   "},
+			want:      nil,
+		},
+		{
+			name: "multiple templates compose independently",
+			templates: []string{
+				`{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}`,
+				`{{label "com.dokku.app-name"}}`,
+				`{{label "com.docker.compose.project"}}.{{label "com.docker.compose.service"}}`,
+			},
+			labels: map[string]string{
+				"com.dokku.app-name":     "docs",
+				"com.dokku.process-type": "web",
+			},
+			want: []string{"docs.web", "docs"},
+		},
+		{
+			name:      "labelOr falls back when label missing",
+			templates: []string{`{{labelOr "com.dokku.app-name" "anonymous"}}`},
+			labels:    map[string]string{},
+			want:      []string{"anonymous"},
+		},
+		{
+			name:      "hasLabel gates a conditional",
+			templates: []string{`{{if hasLabel "com.dokku.process-type"}}{{label "com.dokku.app-name"}}.{{label "com.dokku.process-type"}}{{else}}{{label "com.dokku.app-name"}}{{end}}`},
+			labels:    map[string]string{"com.dokku.app-name": "docs"},
+			want:      []string{"docs"},
+		},
+		{
+			name:      "trailing whitespace trimmed",
+			templates: []string{`  {{label "com.dokku.app-name"}}  `},
+			labels:    map[string]string{"com.dokku.app-name": "docs"},
+			want:      []string{"docs"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpls := make([]*template.Template, len(tc.templates))
+			for i, body := range tc.templates {
+				tmpls[i] = mustParseNameTemplate(t, body)
+			}
+			got := renderNameTemplates(tmpls, "container-name", "container-id", tc.labels)
+			if len(got) == 0 {
+				got = nil
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseNameTemplateRejectsEmpty(t *testing.T) {
+	if _, err := parseNameTemplate(""); err == nil {
+		t.Fatal("expected error for empty template")
+	}
+	if _, err := parseNameTemplate("   "); err == nil {
+		t.Fatal("expected error for whitespace-only template")
+	}
+}

--- a/packaging/Corefile
+++ b/packaging/Corefile
@@ -9,9 +9,9 @@ docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
         ttl 10
         label_prefix com.dokku.coredns-docker
         max_backoff 30s
-        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
-        name_from_labels "{{label \"com.dokku.app-name\"}}"
-        name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
+        name_from_labels "{{if and (hasLabel \"com.dokku.app-name\") (hasLabel \"com.dokku.process-type\")}}{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}{{end}}"
+        name_from_labels "{{if hasLabel \"com.dokku.app-name\"}}{{label \"com.dokku.app-name\"}}{{end}}"
+        name_from_labels "{{if and (hasLabel \"com.docker.compose.project\") (hasLabel \"com.docker.compose.service\")}}{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}{{end}}"
     }
     prometheus :9153
     cache 30

--- a/packaging/Corefile
+++ b/packaging/Corefile
@@ -9,6 +9,9 @@ docker:1053 in-addr.arpa:1053 ip6.arpa:1053 {
         ttl 10
         label_prefix com.dokku.coredns-docker
         max_backoff 30s
+        name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+        name_from_labels "{{label \"com.dokku.app-name\"}}"
+        name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
     }
     prometheus :9153
     cache 30

--- a/setup.go
+++ b/setup.go
@@ -32,8 +32,8 @@ func setup(c *caddy.Controller) error {
 	if err := parse(c, d); err != nil {
 		return plugin.Error(pluginName, err)
 	}
-	log.Debugf("Configuration: zones=[%s], ttl=%d, label_prefix=%q, networks=[%s], max_backoff=%s, host_mode=%t, host_mode_ptr=%t",
-		strings.Join(d.zones, ", "), d.ttl, d.labelPrefix, strings.Join(d.networks, ", "), d.maxBackoff, d.hostMode, d.hostModePTR)
+	log.Debugf("Configuration: zones=[%s], ttl=%d, label_prefix=%q, networks=[%s], max_backoff=%s, host_mode=%t, host_mode_ptr=%t, name_templates=%d",
+		strings.Join(d.zones, ", "), d.ttl, d.labelPrefix, strings.Join(d.networks, ", "), d.maxBackoff, d.hostMode, d.hostModePTR, len(d.nameTemplates))
 
 	// Create a new Docker client.
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -130,6 +130,17 @@ func parse(c *caddy.Controller, d *Docker) error {
 					}
 					d.zones = append(d.zones, z)
 				}
+			case "name_from_labels":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return c.ArgErr()
+				}
+				body := strings.Join(args, " ")
+				tmpl, err := parseNameTemplate(body)
+				if err != nil {
+					return c.Errf("error parsing name_from_labels template: %v", err)
+				}
+				d.nameTemplates = append(d.nameTemplates, tmpl)
 			default:
 				return c.Errf("unknown property '%s'", selector)
 			}

--- a/setup_test.go
+++ b/setup_test.go
@@ -373,3 +373,78 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+func TestParseNameFromLabels(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		shouldErr         bool
+		expectedTemplates int
+	}{
+		{
+			name: "single template",
+			input: `docker {
+				name_from_labels "{{label \"com.dokku.app-name\"}}"
+			}`,
+			shouldErr:         false,
+			expectedTemplates: 1,
+		},
+		{
+			name: "multiple templates accumulate",
+			input: `docker {
+				name_from_labels "{{label \"com.dokku.app-name\"}}.{{label \"com.dokku.process-type\"}}"
+				name_from_labels "{{label \"com.dokku.app-name\"}}"
+				name_from_labels "{{label \"com.docker.compose.project\"}}.{{label \"com.docker.compose.service\"}}"
+			}`,
+			shouldErr:         false,
+			expectedTemplates: 3,
+		},
+		{
+			name: "no argument",
+			input: `docker {
+				name_from_labels
+			}`,
+			shouldErr: true,
+		},
+		{
+			name: "malformed template",
+			input: `docker {
+				name_from_labels "{{label \"com.dokku.app-name\""
+			}`,
+			shouldErr: true,
+		},
+		{
+			name: "empty quoted template",
+			input: `docker {
+				name_from_labels ""
+			}`,
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := caddy.NewTestController("dns", test.input)
+			d := &Docker{
+				labelPrefix: "com.dokku.coredns-docker",
+				maxBackoff:  60 * time.Second,
+				ttl:         DefaultTTL,
+				zones:       []string{"docker."},
+			}
+			err := parse(c, d)
+
+			if test.shouldErr {
+				if err == nil {
+					t.Fatalf("expected error but got none (templates=%d)", len(d.nameTemplates))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error but got %v", err)
+			}
+			if len(d.nameTemplates) != test.expectedTemplates {
+				t.Errorf("expected %d templates, got %d", test.expectedTemplates, len(d.nameTemplates))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Synthesize additional DNS names from arbitrary container labels using Go `text/template` bodies. The directive is repeatable and each template is evaluated independently per container, so multiple containers sharing a label combination collapse onto one multi-A RRSet without an operator-attached plugin label on each container. The shipped packaging Corefile now serves Dokku `<app>.<process-type>` and bare `<app>` names by default alongside the existing Compose `<project>.<service>` collapse, so three Dokku web dynos resolve to a three-IP answer out of the box.