### PR TITLE
fix: emit AAAA records from container GlobalIPv6Address

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1067,15 +1067,27 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 
 		// Generate records for each matching network
 		for _, ne := range networksToProcess {
-			ip := net.ParseIP(ne.settings.IPAddress)
-			if ip == nil {
-				log.Debugf("Container %s has invalid IP address %s on network %s", c.ID, ne.settings.IPAddress, ne.name)
-				continue
+			// Collect the endpoint's IPs. Docker stores the IPv4 address in
+			// IPAddress and the container's global IPv6 address in the separate
+			// GlobalIPv6Address field, so a dual-stack container needs both read
+			// to answer A and AAAA queries. GlobalIPv6Address is empty on
+			// IPv4-only networks, so IPv4-only containers are unaffected. The
+			// A-vs-AAAA split happens at serve time via ip.To4(), so both types
+			// live in the same records slice here.
+			var endpointIPs []net.IP
+			for _, ipStr := range []string{ne.settings.IPAddress, ne.settings.GlobalIPv6Address} {
+				if ipStr == "" {
+					continue
+				}
+				ip := net.ParseIP(ipStr)
+				if ip == nil {
+					log.Debugf("Container %s has invalid IP address %s on network %s", c.ID, ipStr, ne.name)
+					continue
+				}
+				endpointIPs = append(endpointIPs, ip)
 			}
-
-			arpa, arpaErr := dns.ReverseAddr(ip.String())
-			if arpaErr != nil {
-				log.Debugf("Container %s has IP %s that cannot be reversed: %v", c.ID, ip.String(), arpaErr)
+			if len(endpointIPs) == 0 {
+				continue
 			}
 
 			names := []string{baseName}
@@ -1111,19 +1123,27 @@ func generateRecords(ctx context.Context, input GenerateRecordsInput) (map[strin
 					if !strings.HasSuffix(fqdn, ".") {
 						fqdn += "."
 					}
-					// Dedup at the record level to also cover the edge case where
-					// two networks assign the same IP to the same container.
-					if !slices.ContainsFunc(newRecords[fqdn], ip.Equal) {
-						newRecords[fqdn] = append(newRecords[fqdn], ip)
-					}
-					if arpaErr == nil && !slices.Contains(newPtrs[arpa], fqdn) {
-						newPtrs[arpa] = append(newPtrs[arpa], fqdn)
-					}
+					// Emit an A/AAAA record and matching PTR for each of the
+					// endpoint's IPs (IPv4 and, when present, IPv6). Dedup at the
+					// record level also covers the edge case where two networks
+					// assign the same IP to the same container.
+					for _, ip := range endpointIPs {
+						if !slices.ContainsFunc(newRecords[fqdn], ip.Equal) {
+							newRecords[fqdn] = append(newRecords[fqdn], ip)
+						}
 
-					if enableWildcard {
-						wildcardFqdn := "*." + fqdn
-						if !slices.ContainsFunc(newRecords[wildcardFqdn], ip.Equal) {
-							newRecords[wildcardFqdn] = append(newRecords[wildcardFqdn], ip)
+						arpa, arpaErr := dns.ReverseAddr(ip.String())
+						if arpaErr != nil {
+							log.Debugf("Container %s has IP %s that cannot be reversed: %v", c.ID, ip.String(), arpaErr)
+						} else if !slices.Contains(newPtrs[arpa], fqdn) {
+							newPtrs[arpa] = append(newPtrs[arpa], fqdn)
+						}
+
+						if enableWildcard {
+							wildcardFqdn := "*." + fqdn
+							if !slices.ContainsFunc(newRecords[wildcardFqdn], ip.Equal) {
+								newRecords[wildcardFqdn] = append(newRecords[wildcardFqdn], ip)
+							}
 						}
 					}
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -35,6 +35,9 @@ func TestDocker(t *testing.T) {
 			"ipv6.docker.":         {net.ParseIP("2001:db8::1")},
 			"multi.docker.":        {net.ParseIP("172.17.0.4"), net.ParseIP("172.17.0.5")},
 			"myproj.mysvc.docker.": {net.ParseIP("172.17.0.6")},
+			// Dual-stack name: an A query must return only the IPv4 and an
+			// AAAA query only the IPv6, since both live in the same slice.
+			"dual.docker.": {net.ParseIP("172.17.0.7"), net.ParseIP("2001:db8::7")},
 		},
 		srvs: map[string][]srvRecord{
 			"_http._tcp.web.docker.": {
@@ -93,6 +96,24 @@ func TestDocker(t *testing.T) {
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
 				test.AAAA("ipv6.docker.	30	IN	AAAA	2001:db8::1"),
+			},
+		},
+		{
+			// Dual-stack: A query returns only the IPv4 address.
+			Qname: "dual.docker.",
+			Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.A("dual.docker.	30	IN	A	172.17.0.7"),
+			},
+		},
+		{
+			// Dual-stack: AAAA query returns only the IPv6 address.
+			Qname: "dual.docker.",
+			Qtype: dns.TypeAAAA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.AAAA("dual.docker.	30	IN	AAAA	2001:db8::7"),
 			},
 		},
 		{

--- a/docs/examples/12-ipv6/Corefile
+++ b/docs/examples/12-ipv6/Corefile
@@ -1,0 +1,8 @@
+docker.:1053 in-addr.arpa:1053 ip6.arpa:1053 {
+    errors
+    log
+    docker {
+        zone docker.
+        networks ipv6-example-net
+    }
+}

--- a/docs/examples/12-ipv6/docker-compose.yml
+++ b/docs/examples/12-ipv6/docker-compose.yml
@@ -1,0 +1,36 @@
+# IPv6 example: resolve a dual-stack container's AAAA record (and its ip6.arpa PTR).
+#
+# The "ipv6net" network sets enable_ipv6 with an IPv6 subnet, so the container
+# receives both an IPv4 and a global IPv6 address. The plugin emits an A record
+# for the IPv4 and an AAAA record for the IPv6, plus PTR records in both reverse
+# zones.
+#
+# Requires a Docker daemon with IPv6 enabled.
+#
+# Start CoreDNS in one terminal:
+#   coredns-docker -conf Corefile
+#
+# Start the demo container in another:
+#   docker compose up -d
+#
+# Verify:
+#   dig @127.0.0.1 -p 1053 web.docker A +short      # IPv4 address
+#   dig @127.0.0.1 -p 1053 web.docker AAAA +short   # global IPv6 address
+#   dig @127.0.0.1 -p 1053 -x "$(docker inspect -f '{{(index .NetworkSettings.Networks "ipv6-example-net").GlobalIPv6Address}}' ipv6-web)" +short
+
+name: ipv6-example
+
+networks:
+  ipv6net:
+    name: ipv6-example-net
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fd00:dead:beef::/64
+
+services:
+  web:
+    image: nginx:alpine
+    container_name: ipv6-web
+    networks:
+      - ipv6net

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -43,4 +43,5 @@ Each directory in this folder is a runnable demonstration of a specific feature.
 | [09-multiple-zones](09-multiple-zones) | Serving multiple zones from one Corefile |
 | [10-fallthrough](10-fallthrough) | `fallthrough` to the `forward` plugin for upstream resolution |
 | [11-name-from-labels](11-name-from-labels) | `name_from_labels` collapsing multiple containers onto a single multi-A name |
+| [12-ipv6](12-ipv6) | `enable_ipv6` network resolving a container's AAAA record and `ip6.arpa` PTR |
 | [nginx-integration](nginx-integration) | nginx reverse proxy resolving backends via CoreDNS |

--- a/e2e.bats
+++ b/e2e.bats
@@ -65,6 +65,7 @@ teardown_file() {
   # Remove test networks
   docker network rm "$TEST_NETWORK" 2>/dev/null || true
   docker network rm coredns-e2e-unmonitored 2>/dev/null || true
+  docker network rm coredns-e2e-ipv6net 2>/dev/null || true
 
   # Remove temp Corefile
   if [[ -n "$COREFILE" ]]; then
@@ -253,6 +254,78 @@ assert_output_contains() {
   assert_output_contains "ANSWER: 0"
 
   docker rm -f coredns-e2e-v4only
+}
+
+@test "[e2e] AAAA record: IPv6-enabled container resolves and reverses" {
+  local IPV6_NETWORK="coredns-e2e-ipv6net"
+  local IPV6_PORT=15360
+  local IPV6_COREFILE
+  IPV6_COREFILE="$(mktemp /tmp/Corefile.ipv6.XXXXXX)"
+
+  # Create a dual-stack network. Skip when the daemon cannot create IPv6
+  # networks (e.g. CI without IPv6 support) instead of failing the suite.
+  docker network rm "$IPV6_NETWORK" 2>/dev/null || true
+  if ! docker network create --ipv6 --subnet fd00:dead:beef::/64 "$IPV6_NETWORK"; then
+    rm -f "$IPV6_COREFILE"
+    skip "daemon cannot create IPv6 networks"
+  fi
+
+  # Dedicated CoreDNS instance monitoring the IPv6 network on its own port.
+  cat >"$IPV6_COREFILE" <<EOF
+${COREDNS_ZONE}:${IPV6_PORT} in-addr.arpa:${IPV6_PORT} ip6.arpa:${IPV6_PORT} {
+    log
+    errors
+    debug
+    docker {
+        zone ${COREDNS_ZONE}
+        ttl 10
+        networks bridge ${IPV6_NETWORK}
+    }
+}
+EOF
+
+  "$COREDNS_BINARY" -conf "$IPV6_COREFILE" &
+  local IPV6_PID=$!
+
+  local retries=20 i=0
+  while [ "$i" -lt "$retries" ]; do
+    if dig +short +time=1 +tries=1 @127.0.0.1 -p "$IPV6_PORT" version.bind chaos txt >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+
+  docker run -d --name coredns-e2e-ipv6 --network "$IPV6_NETWORK" alpine sleep 3600
+
+  local expected_ip
+  expected_ip=$(docker inspect -f "{{(index .NetworkSettings.Networks \"${IPV6_NETWORK}\").GlobalIPv6Address}}" coredns-e2e-ipv6)
+
+  if [[ -z "$expected_ip" ]]; then
+    docker rm -f coredns-e2e-ipv6
+    kill "$IPV6_PID" 2>/dev/null || true
+    wait "$IPV6_PID" 2>/dev/null || true
+    rm -f "$IPV6_COREFILE"
+    docker network rm "$IPV6_NETWORK" 2>/dev/null || true
+    skip "container did not receive a GlobalIPv6Address"
+  fi
+
+  # AAAA forward lookup returns the container's global IPv6 address.
+  run wait_for_record_on_port "coredns-e2e-ipv6.${COREDNS_ZONE}" "AAAA" "$IPV6_PORT"
+  assert_success
+  assert_equal "$expected_ip" "$output"
+
+  # ip6.arpa PTR resolves back to the container FQDN.
+  run dig +short +time=2 +tries=1 @127.0.0.1 -p "$IPV6_PORT" -x "$expected_ip"
+  assert_success
+  assert_output_contains "coredns-e2e-ipv6.${COREDNS_ZONE}."
+
+  # Cleanup
+  docker rm -f coredns-e2e-ipv6
+  kill "$IPV6_PID" 2>/dev/null || true
+  wait "$IPV6_PID" 2>/dev/null || true
+  rm -f "$IPV6_COREFILE"
+  docker network rm "$IPV6_NETWORK" 2>/dev/null || true
 }
 
 @test "[e2e] nonexistent container: query returns NXDOMAIN" {

--- a/generate_records_test.go
+++ b/generate_records_test.go
@@ -94,6 +94,186 @@ func TestGenerateRecords(t *testing.T) {
 			},
 		},
 		{
+			name: "dual-stack container emits A and AAAA records",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress:           "172.17.0.2",
+										GlobalIPv6Address:   "2001:db8::2",
+										GlobalIPv6PrefixLen: 64,
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				// IPv4 is parsed first, so the slice is ordered [v4, v6]. The
+				// A-vs-AAAA split happens at serve time via ip.To4().
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2"), net.ParseIP("2001:db8::2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{
+					mustReverseAddr("172.17.0.2"):  {"web.docker."},
+					mustReverseAddr("2001:db8::2"): {"web.docker."},
+				},
+			},
+		},
+		{
+			name: "IPv6-only container emits AAAA record",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										GlobalIPv6Address:   "2001:db8::2",
+										GlobalIPv6PrefixLen: 64,
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				// An IPv6-only network leaves IPAddress empty; only the AAAA
+				// record and its ip6.arpa PTR are emitted.
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("2001:db8::2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{
+					mustReverseAddr("2001:db8::2"): {"web.docker."},
+				},
+			},
+		},
+		{
+			name: "invalid GlobalIPv6Address is skipped but IPv4 still emitted",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress:         "172.17.0.2",
+										GlobalIPv6Address: "not-an-ip",
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				// A bad IPv6 address is skipped individually, so the valid
+				// IPv4 record is still emitted rather than the whole network
+				// being dropped.
+				records: map[string][]net.IP{
+					"web.docker.": {net.ParseIP("172.17.0.2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{mustReverseAddr("172.17.0.2"): {"web.docker."}},
+			},
+		},
+		{
+			name: "dual-stack container with wildcard emits wildcard A and AAAA",
+			input: GenerateRecordsInput{
+				Inspector: &mockContainerInspector{
+					inspections: map[string]container.InspectResponse{
+						"container1": {
+							ContainerJSONBase: &container.ContainerJSONBase{
+								Name: "/web",
+								HostConfig: &container.HostConfig{
+									NetworkMode: container.NetworkMode("bridge"),
+								},
+							},
+							Config: &container.Config{
+								Labels: map[string]string{
+									"com.dokku.coredns-docker/wildcard": "true",
+								},
+							},
+							NetworkSettings: &container.NetworkSettings{
+								Networks: map[string]*network.EndpointSettings{
+									"bridge": {
+										IPAddress:           "172.17.0.2",
+										GlobalIPv6Address:   "2001:db8::2",
+										GlobalIPv6PrefixLen: 64,
+									},
+								},
+							},
+						},
+					},
+				},
+				Containers: []container.Summary{
+					{ID: "container1"},
+				},
+				Zones:       []string{"docker."},
+				LabelPrefix: "com.dokku.coredns-docker",
+			},
+			expected: generateRecordsExpected{
+				records: map[string][]net.IP{
+					"web.docker.":   {net.ParseIP("172.17.0.2"), net.ParseIP("2001:db8::2")},
+					"*.web.docker.": {net.ParseIP("172.17.0.2"), net.ParseIP("2001:db8::2")},
+				},
+				srvs: map[string][]srvRecord{},
+				ptrs: map[string][]string{
+					mustReverseAddr("172.17.0.2"):  {"web.docker."},
+					mustReverseAddr("2001:db8::2"): {"web.docker."},
+				},
+			},
+		},
+		{
 			name: "container with network aliases",
 			input: GenerateRecordsInput{
 				Inspector: &mockContainerInspector{

--- a/integration_test.go
+++ b/integration_test.go
@@ -344,6 +344,79 @@ func TestIntegrationNetworkAlias(t *testing.T) {
 	}
 }
 
+func TestIntegrationIPv6AAAARecord(t *testing.T) {
+	networkName := testNetworkPrefix + "ipv6"
+	d, cli := setupIntegrationDocker(t, []string{networkName})
+	ctx := context.Background()
+
+	// Create an IPv6-enabled network. EnableIPv6 is a *bool in the Docker API,
+	// and an explicit IPv6 subnet is required. Skip the test gracefully when
+	// the daemon cannot create IPv6 networks (common in CI without IPv6).
+	enableIPv6 := true
+	netResp, err := cli.NetworkCreate(ctx, networkName, network.CreateOptions{
+		Driver:     "bridge",
+		EnableIPv6: &enableIPv6,
+		IPAM: &network.IPAM{
+			Config: []network.IPAMConfig{
+				{Subnet: "fd00:dead:beef::/64"},
+			},
+		},
+	})
+	if err != nil {
+		t.Skipf("Skipping IPv6 test: cannot create IPv6 network: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cli.NetworkRemove(context.Background(), netResp.ID)
+	})
+
+	name := testContainerName(t, "")
+	createTestContainer(t, cli, name, &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"},
+	}, &container.HostConfig{
+		NetworkMode: container.NetworkMode(networkName),
+	}, &network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			networkName: {},
+		},
+	})
+
+	// Read the container's assigned global IPv6 address to compare against. If
+	// the daemon accepted the network but did not assign an IPv6 address, IPv6
+	// is not functional here, so skip rather than fail.
+	inspect, err := cli.ContainerInspect(ctx, name)
+	if err != nil {
+		t.Fatalf("Failed to inspect container %s: %v", name, err)
+	}
+	epSettings, ok := inspect.NetworkSettings.Networks[networkName]
+	if !ok || epSettings.GlobalIPv6Address == "" {
+		t.Skip("Skipping IPv6 test: container has no GlobalIPv6Address (daemon IPv6 not functional)")
+	}
+	wantIP := net.ParseIP(epSettings.GlobalIPv6Address)
+
+	d.syncRecords(ctx)
+
+	fqdn := name + ".docker."
+	resp, _, err := queryDNS(t, d, fqdn, dns.TypeAAAA)
+	if err != nil {
+		t.Fatalf("ServeDNS error for %s: %v", fqdn, err)
+	}
+	if resp == nil || len(resp.Answer) == 0 {
+		t.Fatalf("expected at least one AAAA record for %s, got none", fqdn)
+	}
+
+	aaaa, ok := resp.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("expected AAAA record, got %T", resp.Answer[0])
+	}
+	if aaaa.AAAA == nil || aaaa.AAAA.To4() != nil {
+		t.Fatalf("expected a valid IPv6 address, got %v", aaaa.AAAA)
+	}
+	if !aaaa.AAAA.Equal(wantIP) {
+		t.Errorf("expected AAAA %s, got %s", wantIP, aaaa.AAAA)
+	}
+}
+
 func TestIntegrationFallthrough(t *testing.T) {
 	d, cli := setupIntegrationDocker(t, nil)
 	d.Fall = fall.Root


### PR DESCRIPTION
AAAA queries for IPv6-enabled containers returned NODATA because record generation only read each network endpoint's IPv4 `IPAddress` and ignored `GlobalIPv6Address`. Both addresses are now collected, so a container answers both A and AAAA queries along with PTR records in the `ip6.arpa` reverse zone, while IPv4-only containers are unaffected.

Closes #90