### PR TITLE
feat: publish multi-arch docker image to docker hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 Dockerfile*
 LICENSE
 README.md
+.coredns-build
+.git
+coverage.out
+tmp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,3 +161,31 @@ jobs:
         with:
           name: build
           path: build/**/*
+
+  docker:
+    name: docker
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download linux binaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: binary-linux-*
+      - name: Reconstruct build directory
+        run: |
+          mkdir -p build/linux
+          for arch in amd64 arm arm64 mips64le ppc64le s390x mips riscv64; do
+            cp "binary-linux-${arch}/coredns-docker-${arch}" "build/linux/coredns-docker-${arch}"
+          done
+          chmod +x build/linux/*
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
+      - name: Test docker image
+        run: make test-docker
+      - name: Build multi-arch image
+        run: make build-hub-image

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -97,3 +97,17 @@ jobs:
           files: dist/*
           generate_release_notes: true
           make_latest: "true"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push multi-arch image
+        run: make release-hub-image
+        env:
+          IMAGE_NAME: dokku/coredns-docker

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,3 +1,4 @@
 FROM scratch
-COPY ./build/linux/coredns-docker-amd64 /coredns-docker
+ARG TARGETARCH
+COPY ./build/linux/coredns-docker-${TARGETARCH} /coredns-docker
 ENTRYPOINT ["/coredns-docker"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 BASE_VERSION ?= 0.1.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x,linux/riscv64,linux/mips,linux/mips64le
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 
 ifeq ($(CI_BRANCH),release)
@@ -86,6 +87,14 @@ build:
 
 build-docker-image:
 	docker build --rm -q -f Dockerfile -t $(IMAGE_NAME):build .
+
+.PHONY: build-hub-image
+build-hub-image:
+	docker buildx build --provenance=false --platform $(DOCKER_PLATFORMS) -f Dockerfile.hub -t $(IMAGE_NAME):$(DOCKER_IMAGE_VERSION) .
+
+.PHONY: release-hub-image
+release-hub-image:
+	docker buildx build --provenance=mode=max --sbom=true --push --platform $(DOCKER_PLATFORMS) -f Dockerfile.hub -t $(IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -t $(IMAGE_NAME):latest .
 
 $(targets): %-in-docker: .env.docker
 	docker run \
@@ -240,6 +249,10 @@ test:
 .PHONY: test-e2e
 test-e2e: build-local
 	bats e2e.bats
+
+.PHONY: test-docker
+test-docker:
+	bats docker.bats
 
 .PHONY: test-integration
 test-integration:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ chmod +x coredns-docker
 sudo mv coredns-docker /usr/local/bin/
 ```
 
+Or pull the multi-arch image from Docker Hub:
+
+```bash
+docker pull dokku/coredns-docker:latest
+```
+
 Or build a single binary from source (requires Go):
 
 ```bash

--- a/docker.bats
+++ b/docker.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+export IMAGE="coredns-docker:bats-test"
+
+# Map `uname -m` to the GOARCH used for the build/linux/coredns-docker-* binaries.
+host_goarch() {
+  case "$(uname -m)" in
+  x86_64 | amd64) echo "amd64" ;;
+  aarch64 | arm64) echo "arm64" ;;
+  armv7l | armv6l | arm) echo "arm" ;;
+  ppc64le) echo "ppc64le" ;;
+  s390x) echo "s390x" ;;
+  riscv64) echo "riscv64" ;;
+  mips64 | mips64le) echo "mips64le" ;;
+  mips) echo "mips" ;;
+  *) echo "" ;;
+  esac
+}
+
+setup_file() {
+  local goarch binary
+  goarch="$(host_goarch)"
+  binary="build/linux/coredns-docker-${goarch}"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    export SKIP_REASON="docker is not installed"
+    return 0
+  fi
+  if ! docker buildx version >/dev/null 2>&1; then
+    export SKIP_REASON="docker buildx is not available"
+    return 0
+  fi
+  if [[ -z "$goarch" ]]; then
+    export SKIP_REASON="unsupported host architecture: $(uname -m)"
+    return 0
+  fi
+  if [[ ! -f "$binary" ]]; then
+    export SKIP_REASON="missing $binary (run 'make build' first)"
+    return 0
+  fi
+
+  # Build the image for the host architecture. --load produces a single-arch
+  # image in the local docker regardless of whether the active buildx builder
+  # is the default `docker` driver or a `docker-container` one.
+  docker buildx build --load -t "$IMAGE" -f Dockerfile.hub .
+}
+
+teardown_file() {
+  docker image rm -f "$IMAGE" >/dev/null 2>&1 || true
+}
+
+@test "hub image reports the docker plugin" {
+  [[ -z "$SKIP_REASON" ]] || skip "$SKIP_REASON"
+
+  run docker run --rm "$IMAGE" -plugins
+  echo "status: $status"
+  echo "output: $output"
+  [ "$status" -eq 0 ]
+  # `-plugins` lists the compiled-in plugin as a bare `docker` line (older
+  # CoreDNS printed `dns.docker`); accept either form.
+  echo "$output" | grep -Eq '(^|\.)docker$'
+}

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -26,7 +26,7 @@ Each directory in this folder is a runnable demonstration of a specific feature.
    # then Ctrl-C the CoreDNS terminal
    ```
 
-**Why run CoreDNS on the host and services in Compose?** The plugin needs access to `/var/run/docker.sock` to watch containers. Running CoreDNS on the host avoids any container-in-container DNS bootstrapping issues and keeps the examples minimal. If you would rather run CoreDNS in Compose too, build a local image from `Dockerfile.hub` and add a service that mounts the socket (see [../installation.md](../installation.md#docker-image)).
+**Why run CoreDNS on the host and services in Compose?** The plugin needs access to `/var/run/docker.sock` to watch containers. Running CoreDNS on the host avoids any container-in-container DNS bootstrapping issues and keeps the examples minimal. If you would rather run CoreDNS in Compose too, use the published `dokku/coredns-docker` image (or build a local one from `Dockerfile.hub`) and add a service that mounts the socket (see [../installation.md](../installation.md#docker-image)).
 
 ## Example index
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,14 +66,17 @@ This produces the full build matrix under `build/` and `.deb` packages under `bu
 
 ## Docker image
 
-The repository ships a `Dockerfile.hub` that wraps the Linux amd64 binary in a `scratch` image. There is no automatically published image, so you need to build it yourself after running `make build`:
+Each release publishes a multi-arch image to Docker Hub at [`dokku/coredns-docker`](https://hub.docker.com/r/dokku/coredns-docker). `latest` tracks the newest release, and every release also gets an immutable version tag:
 
 ```bash
-make build
-docker build -t coredns-docker:local -f Dockerfile.hub .
+docker pull dokku/coredns-docker:latest
+# or pin a version
+docker pull dokku/coredns-docker:0.6.1
 ```
 
-Then run CoreDNS in a container, bind-mounting your `Corefile` and the Docker socket:
+The manifest covers `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/ppc64le`, `linux/s390x`, `linux/riscv64`, `linux/mips`, and `linux/mips64le`, so `docker pull` selects the right binary for your host automatically. Each image is a `scratch` image containing only the static CoreDNS binary, and carries SLSA build provenance and an SBOM you can inspect with `docker buildx imagetools inspect dokku/coredns-docker:latest`.
+
+Run CoreDNS in a container, bind-mounting your `Corefile` and the Docker socket:
 
 ```bash
 docker run --rm -d \
@@ -81,10 +84,19 @@ docker run --rm -d \
     -p 1053:1053/udp -p 1053:1053/tcp \
     -v "$PWD/Corefile:/Corefile:ro" \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
-    coredns-docker:local -conf /Corefile
+    dokku/coredns-docker:latest -conf /Corefile
 ```
 
 **Why mount the Docker socket?** The plugin uses the Docker API to list containers and subscribe to events. Without the socket inside the container, there is nothing for it to listen to. The mount is `:ro` because the plugin only needs to read container state.
+
+**Building the image yourself.** The repository ships the `Dockerfile.hub` that the release uses. It selects the binary for the target architecture (`TARGETARCH`) out of `build/linux/`, so build it after `make build`:
+
+```bash
+make build
+docker build -t coredns-docker:local -f Dockerfile.hub .
+```
+
+That produces a single image for your host architecture. To assemble the full multi-arch manifest locally, create a `docker-container` builder once (`docker buildx create --use`) and run `make build-hub-image`.
 
 ## Verifying the install
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,6 +66,30 @@ make test-e2e
 #  ...
 ```
 
+## Docker image
+
+```bash
+make test-docker
+```
+
+This runs `bats docker.bats`, which builds the `Dockerfile.hub` image for your host architecture (via `docker buildx build --load`) and asserts that the `docker` plugin is compiled in by running the image with `-plugins` and checking that the plugin is listed. It is the same check the CI `docker` job runs before it validates the full multi-arch build.
+
+**When to use it:** any change to `Dockerfile.hub`, the `build-hub-image`/`release-hub-image` targets, or the release pipeline that publishes the image to Docker Hub.
+
+**Requirements:**
+
+- A running Docker daemon with `buildx`
+- [bats-core](https://github.com/bats-core/bats-core) 1.5 or newer
+- The output of `make build` (the test copies `build/linux/coredns-docker-<arch>` into the image and skips cleanly if that binary is missing)
+
+**Example:**
+
+```bash
+make build
+make test-docker
+#  ✓ hub image reports the docker plugin
+```
+
 ## Coverage
 
 ```bash


### PR DESCRIPTION
The image is built for all eight release architectures on every commit but is only pushed to Docker Hub for release tags, where `latest` tracks the newest release and every version also gets an immutable tag. Pushed images carry SLSA build provenance and an SBOM.

Pushing to Docker Hub requires two new repository secrets, `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, where the token has write access to the `dokku/coredns-docker` repository. Until they are configured the release push step fails, while the build-only validation that runs on every commit is unaffected.

Closes #92.